### PR TITLE
Hotfix for HashMap.entrySet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 **Native Library** brings productivity and maintainability for your C/C++ application as a Java program.
 
-* Blazing fast performance, small footprint with no dependency required
-* Provide rich Java Core classes compare to C++/STL
-* Zero memory leak and prevents segfaults via automatic storage
-* C++ and Java developers can use strength of two languages
+* Blazing fast, small footprint with no dependency required
+* Provide rich Java Core classes beside C++ Standard Library
+* Prevents nearly all memory leak and  segfaults via automatic storage
 * Support bindings for NodeJS addon and Python module development (experimental)
 * Classes are strictly tested with unit tests, clean with Valgrind and follow Oracle documentation
 * Feel free to use in your commercial products and welcome for contributions
@@ -50,6 +49,7 @@ public:
             hashMap.put("argument " + String::valueOf(counter), argument);
             counter++;
         }
+        System::out::println("We have 4 pairs:");
         String pairs = "Pairs: \n";
         for (Map<String, String>::Entry entry : hashMap.entrySet()) {
             pairs += entry.getKey() + String(" - ") + entry.getValue() + String("\n");

--- a/java/lang/Object/ObjectTest.cpp
+++ b/java/lang/Object/ObjectTest.cpp
@@ -25,10 +25,7 @@
  */
 
 #include "../../../kernel/Test.hpp"
-#include "../String/String.hpp"
-#include "../Integer/Integer.hpp"
-#include "../Long/Long.hpp"
-#include "../System/System.hpp"
+#include "../../util/HashMap/HashMap.hpp"
 
 using namespace Java::Lang;
 
@@ -105,6 +102,14 @@ TEST (JavaLang, DataTypeArray) {
 	// Retrieve  elements from an existing array
 	assertEquals("Food", initializedStrings.get(0).toString());
 	assertEquals("Tiny", initializedStrings.get(1).toString());
+	
+	Array<HashMap<String, String>*> arrayHashMap;
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value1");
+	arrayHashMap.push(&hashMap);
+	for (auto hashMap : arrayHashMap) {
+		assertEquals("Value1", hashMap->get("Key1").toString());
+	}
 }
 
 TEST (JavaLang, ArrayConstructorWithSize) {

--- a/java/util/HashMap/HashMap.hpp
+++ b/java/util/HashMap/HashMap.hpp
@@ -423,7 +423,7 @@ namespace Java {
                 Set<class Map<Key, Value>::Entry> entrySet;
 
                 for (auto const &pair : this->original) {
-                    Map<String, String>::Entry entry(pair.first, pair.second);
+                    class Map<Key, Value>::Entry entry(pair.first, pair.second);
                     entrySet.add(entry);
                 }
 

--- a/java/util/HashMap/HashMapTest.cpp
+++ b/java/util/HashMap/HashMapTest.cpp
@@ -175,6 +175,8 @@ TEST (JavaUtil, HashMapEntrySet) {
     hashMapStringPointer.put("test3", new String("test1"));
 	for (Map<String, String*>::Entry entry : hashMapStringPointer.entrySet()) {
 		assertEquals("test1", entry.getValue()->toString());
+        String *stringValue = entry.getValue();
+        delete stringValue;
 	}
 }
 
@@ -852,7 +854,7 @@ TEST (JavaUtil, HashMapReinitialize) {
 //    assertEquals(2, hashMap.size());
 //    assertEquals(0, resultComputeIfPresentDefaultValueHashMap.intValue());
 //}
-//
+
 //TEST(JavaUtil, HashMapForEach) {
 //    /* Test HashMap<String, Integer> */
 //        // Create a HashMap
@@ -862,10 +864,9 @@ TEST (JavaUtil, HashMapReinitialize) {
 //    Integer result;
 //
 //        // Create function
-//    std::function<void(String, Integer)> function
-//            = [] (String key, Integer value) {
-//                printf("TEST(JavaUtil, HashMapForEach) is OK");
-//            };
+//    std::function<void(String, Integer)> function = [] (String key, Integer value) {
+//            printf("TEST(JavaUtil, HashMapForEach) is OK");
+//    };
 //
 //        // foreach
 //    hashMap.forEach(function);

--- a/java/util/HashMap/HashMapTest.cpp
+++ b/java/util/HashMap/HashMapTest.cpp
@@ -146,17 +146,13 @@ TEST (JavaUtil, HashMapContainsValue) {
 
 TEST (JavaUtil, HashMapEntrySet) {
     HashMap<String, String> hashMap;
-
     int index = 1;
-
     for (index; index <= 100; index++) {
         hashMap.put("Key " + String::valueOf(index),
                     "Value " + String::valueOf(index));
     }
-
     int counter = 0;
     Set<class Map<String, String>::Entry> entrySet = hashMap.entrySet();
-
     // TODO - loint@foodtiny.com will improve entrySet
     // then we can put it inside foreach without any performance issue
     for (Map<String, String>::Entry entry : entrySet) {
@@ -170,9 +166,16 @@ TEST (JavaUtil, HashMapEntrySet) {
             assertEquals("Value 98", entry.getValue().toString());
         }
     }
-
     // Make sure foreach is working
     assertEquals(100, counter);
+    
+    HashMap<String, String*> hashMapStringPointer;
+    hashMapStringPointer.put("test1", new String("test1"));
+    hashMapStringPointer.put("test2", new String("test1"));
+    hashMapStringPointer.put("test3", new String("test1"));
+	for (Map<String, String*>::Entry entry : hashMapStringPointer.entrySet()) {
+		assertEquals("test1", entry.getValue()->toString());
+	}
 }
 
 TEST (JavaUtil, HashMapGet) {


### PR DESCRIPTION
Syntax error happened in this case
```cpp
static HashMap<String, Abstraction::Service*> services;
services.put("mysql", new MySQLService());
services.put("sqlite", new SQLiteService());
```

HashMap is ONLY support for normal data type and panic syntax error when we're trying to pass a pointer reference as a HashMap value.
This bug was already fixed by removing hard coded Key, Value and improved with keyword `class` in C++ 
for Map<Key, Value>
