### PR TITLE
Hot fix for Java::Util::HashMap and Java::Lang::Byte

### DIFF
--- a/.vscode/.cmaketools.json
+++ b/.vscode/.cmaketools.json
@@ -1,0 +1,5 @@
+{
+  "variant": null,
+  "activeEnvironments": [],
+  "codeModel": null
+}

--- a/.vscode/.cmaketools.json
+++ b/.vscode/.cmaketools.json
@@ -1,5 +1,0 @@
-{
-  "variant": null,
-  "activeEnvironments": [],
-  "codeModel": null
-}

--- a/java/lang/Byte/Byte.cpp
+++ b/java/lang/Byte/Byte.cpp
@@ -32,58 +32,58 @@ using namespace Java::Lang;
 
 ByteCache *ByteCache::instance = nullptr;
 
-Bytes::Bytes(byte byteValue) {
+Byte::Byte(byte byteValue) {
 	this->original = byteValue;
     this->originalString = stringFromInt(this->original);
 }
 
-Bytes::Bytes(String inputString) {
+Byte::Byte(String inputString) {
 	this->original = parseByte(inputString, 10);
     this->originalString = stringFromInt(this->original);
 }
 
-Bytes::Bytes() {
+Byte::Byte() {
     this->original = 0;
     this->originalString = stringCopy("0");
 }
 
-Bytes::~Bytes() {
+Byte::~Byte() {
     if (this->originalString != nullptr) {
         free(this->originalString);
     }
 }
 
-char Bytes::charValue() const {
+char Byte::charValue() const {
     return (char) this->original;
 }
 
-byte Bytes::byteValue() const {
+byte Byte::byteValue() const {
 	return this->original;
 }
 
-int Bytes::compare(byte byteA, byte byteB) {
+int Byte::compare(byte byteA, byte byteB) {
     return byteA - byteB;
 }
 
-int Bytes::compareTo(const Bytes &other) const {
+int Byte::compareTo(const Byte &other) const {
 	return this->original - other.original;
 }
 
-Bytes Bytes::decode(String stringToDecode) {
+Byte Byte::decode(String stringToDecode) {
     int value = Integer::decode(stringToDecode).intValue();
-    if (value < Bytes::MIN_VALUE || value > Bytes::MAX_VALUE) {
+    if (value < Byte::MIN_VALUE || value > Byte::MAX_VALUE) {
         throw NumberFormatException("out of byte range");
     }
     return (byte) value;
 }
 
-double Bytes::doubleValue() const {
+double Byte::doubleValue() const {
 	return (double) this->original;
 }
 
 //TODO need instanceof
-boolean Bytes::equals(Bytes object) {
-//    boolean isByte = instanceof<Bytes>(object);
+boolean Byte::equals(Byte object) {
+//    boolean isByte = instanceof<Byte>(object);
 //	if (isByte) {
 //        return this->original == parseByte(object.toString());
 //    }
@@ -91,142 +91,142 @@ boolean Bytes::equals(Bytes object) {
     return this->original == parseByte(object.toString());
 }
 
-float Bytes::floatValue() const {
+float Byte::floatValue() const {
     return (float) this->original;
 }
 
-long Bytes::hashCode() const {
+long Byte::hashCode() const {
     return (long) this->original;
 }
 
-int Bytes::hashCode(byte value) {
+int Byte::hashCode(byte value) {
     return (int) value;
 }
 
-int Bytes::intValue() const {
+int Byte::intValue() const {
     return (int) this->original;
 }
 
-long Bytes::longValue() const {
+long Byte::longValue() const {
     return (long) this->original;
 }
 
-byte Bytes::parseByte(String stringToParse) {
+byte Byte::parseByte(String stringToParse) {
 	return parseByte(stringToParse, 10);
 }
 
-byte Bytes::parseByte(String stringToParse, int radix) {
+byte Byte::parseByte(String stringToParse, int radix) {
     int value = Integer::parseInt(stringToParse, radix);
-    if (value < Bytes::MIN_VALUE || value > Bytes::MAX_VALUE) {
+    if (value < Byte::MIN_VALUE || value > Byte::MAX_VALUE) {
         throw NumberFormatException("out of byte range");
     }
     return (byte)value;
 }
 
-short Bytes::shortValue() const {
+short Byte::shortValue() const {
     return (short) this->original;
 }
 
-string Bytes::toString() const {
+string Byte::toString() const {
     return this->originalString;
 }
 
-String Bytes::toString(byte byteValue) {
+String Byte::toString(byte byteValue) {
     return Integer::toString((int) byteValue, 10);
 }
 
-int Bytes::toUnsignedInt(byte byteValue) {
+int Byte::toUnsignedInt(byte byteValue) {
     return ((int) byteValue) & 0xff;
 }
 
-long Bytes::toUnsignedLong(byte byteValue) {
+long Byte::toUnsignedLong(byte byteValue) {
     return ((long) byteValue) & 0xffL;
 }
 
-Bytes Bytes::valueOf(byte byteValue) {
+Byte Byte::valueOf(byte byteValue) {
     return ByteCache::getInstance()->getByteAtIndex((int) byteValue);
 }
 
-Bytes Bytes::valueOf(String stringValue) {
-    return Bytes(parseByte(stringValue));
+Byte Byte::valueOf(String stringValue) {
+    return Byte(parseByte(stringValue));
 }
 
-Bytes Bytes::valueOf(String stringValue, int radix) {
-    return Bytes(parseByte(stringValue, radix));
+Byte Byte::valueOf(String stringValue, int radix) {
+    return Byte(parseByte(stringValue, radix));
 }
 
-Bytes Bytes::operator+(const Bytes &target) {
+Byte Byte::operator+(const Byte &target) {
 	return this->original + target.original;
 }
 
-Bytes Bytes::operator-(const Bytes &target) {
+Byte Byte::operator-(const Byte &target) {
 	return this->original - target.original;
 }
 
-Bytes Bytes::operator/(const Bytes &target) {
+Byte Byte::operator/(const Byte &target) {
     if (target.intValue() == 0) {
         throw ArithmeticException("Divide by zero");
     }
 	return this->original / target.original;
 }
 
-Bytes Bytes::operator%(const Bytes &target) {
+Byte Byte::operator%(const Byte &target) {
     if (target.intValue() == 0) {
         throw ArithmeticException("Divide by zero");
     }
 	return this->original % target.original;
 }
 
-Bytes Bytes::operator*(const Bytes &target) {
+Byte Byte::operator*(const Byte &target) {
 	return this->original * target.original;
 }
 
-boolean Bytes::operator==(const Bytes &target) {
+boolean Byte::operator==(const Byte &target) {
 	return this->original == target.original;
 }
 
-boolean Bytes::operator!=(const Bytes &target) {
+boolean Byte::operator!=(const Byte &target) {
 	return this->original != target.original;
 }
 
-boolean Bytes::operator<(const Bytes &target) {
+boolean Byte::operator<(const Byte &target) {
 	return this->original < target.original;
 }
 
-boolean Bytes::operator>(const Bytes &target) {
+boolean Byte::operator>(const Byte &target) {
 	return this->original > target.original;
 }
 
-boolean Bytes::operator<=(const Bytes &target) {
+boolean Byte::operator<=(const Byte &target) {
 	return this->original <= target.original;
 }
 
-boolean Bytes::operator>=(const  Bytes &target) {
+boolean Byte::operator>=(const  Byte &target) {
 	return this->original >= target.original;
 }
 
-Bytes &Bytes::operator-=(const Bytes &target) {
+Byte &Byte::operator-=(const Byte &target) {
     free((this->originalString));
     this->original -= target.original;
     this->originalString = stringFromInt(this->original);
     return *this;
 }
 
-Bytes &Bytes::operator+=(const Bytes &target) {
+Byte &Byte::operator+=(const Byte &target) {
     free((this->originalString));
     this->original += target.original;
     this->originalString = stringFromInt(this->original);
     return *this;
 }
 
-Bytes &Bytes::operator*=(const Bytes &target) {
+Byte &Byte::operator*=(const Byte &target) {
     free((this->originalString));
     this->original *= target.original;
     this->originalString = stringFromInt(this->original);
     return *this;
 }
 
-Bytes &Bytes::operator/=(const Bytes &target) {
+Byte &Byte::operator/=(const Byte &target) {
     if (target.intValue() == 0) {
         throw ArithmeticException("Divide by zero");
     }
@@ -236,7 +236,7 @@ Bytes &Bytes::operator/=(const Bytes &target) {
     return *this;
 }
 
-Bytes &Bytes::operator%=(const Bytes &target) {
+Byte &Byte::operator%=(const Byte &target) {
     if (target.intValue() == 0) {
         throw ArithmeticException("Divide by zero");
     }
@@ -246,14 +246,14 @@ Bytes &Bytes::operator%=(const Bytes &target) {
     return *this;
 }
 
-Bytes &Bytes::operator=(const Bytes &target) {
+Byte &Byte::operator=(const Byte &target) {
     free((this->originalString));
     this->original = target.original;
     this->originalString = stringFromInt(this->original);
     return *this;
 }
 
-Bytes::Bytes(const Bytes &anotherBytes) {
-    this->original = anotherBytes.original;
+Byte::Byte(const Byte &anotherByte) {
+    this->original = anotherByte.original;
     this->originalString = stringFromInt(this->original);
 }

--- a/java/lang/Byte/Byte.hpp
+++ b/java/lang/Byte/Byte.hpp
@@ -23,7 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #ifndef NATIVE_JAVA_LANG_BYTE_HPP
 #define NATIVE_JAVA_LANG_BYTE_HPP
 
@@ -33,426 +33,440 @@
 #include "../../../kernel/Type.hpp"
 
 namespace Java {
-	namespace Lang {
+		namespace Lang {
+				
+				class Byte;
+				
+				class Byte :
+					public virtual Number,
+					public virtual Comparable<Byte> {
+				private:
+						byte original;
+						string originalString;
+				
+				public:
+						/**
+						 * Min value of Byte
+						 */
+						static const byte MIN_VALUE = 0;
+						
+						/**
+						 * Max value of Byte
+						 */
+						static const byte MAX_VALUE = 255;
+						
+						/**
+						 * The number of bits used to represent a byte value in two's complement binary form.
+						 */
+						static const int SIZE = 8;
+						
+						/**
+						 * The number of bytes used to represent a byte value in two's complement binary form.
+						 */
+						static constexpr int BYTES = 1;
+				
+				public:
+						/**
+						 * Default constructor
+						 */
+						Byte();
+						
+						/**
+						 * Construct a new Byte with the value of byte
+						 *
+						 * @param byteValue
+						 */
+						Byte(byte byteValue);
+						
+						/**
+						 * Construct a new Byte with the value of String
+						 *
+						 * @param inputString
+						 * @throw NumberFormatException If inputString does not contain a parsable byte.
+						 */
+						Byte(String inputString);
+						
+						/**
+						 * Copy constructor
+						 *
+						 * @param anotherByte
+						 */
+						Byte(const Byte &anotherByte);
+						
+						/**
+						 * Destructor, free memory allocated for originalString.
+						 */
+						~Byte();
+				
+				public:
+						
+						/**
+						 *Return the value of this Byte as a char
+						 *
+						 * @return char
+						 */
+						char charValue() const;
+						
+						/**
+						 * Byte value
+						 *
+						 * @return byte
+						 */
+						byte byteValue() const;
+						
+						/**
+						 * Compares two byte values numerically.
+						 *
+						 * @param byteA
+						 * @param byteB
+						 * @return the value 0 if byteA == byteB; a value less than 0 if byteA < byteB;
+						 * and a value greater than 0 if byteA > byteB
+						 */
+						static int compare(byte byteA, byte byteB);
+						
+						/**
+						 * Compares two Byte objects numerically
+						 *
+						 * @param other
+						 * @return the value 0 if this Byte is equal to other;
+						 * a value less than 0 if this Byte is numerically less than other;
+						 * and a value greater than 0 if this Byte is numerically greater than other
+						 */
+						int compareTo(const Byte &other) const override;
+						
+						/**
+						 * Decodes a String into a Byte. Accepts decimal, hexadecimal, and octal numbers
+						 *
+						 * @param stringToDecode
+						 * @throw NumberFormatException - if the String does not contain a parsable byte.
+						 * @return a Byte object holding the byte value represented by stringToDecode
+						 */
+						static Byte decode(String stringToDecode);
+						
+						/**
+						 * Double value of Byte
+						 *
+						 * @return double
+						 */
+						double doubleValue() const override;
+						
+						/**
+						 * Compare this Byte to another Byte object
+						 *
+						 * @param object
+						 * @return true if object is a Byte and has the same value as this Byte; false otherwise
+						 */
+						// TODO need instanceof temporary use Byte instead of Object
+						boolean equals(Byte object);
+						
+						/**
+						 * Returns the value of this Byte as an float.
+						 *
+						 * @return float
+						 */
+						float floatValue() const override;
+						
+						/**
+						 * Returns a hash code for this Byte
+						 *
+						 * @return long
+						 */
+						long hashCode() const override;
+						
+						/**
+						 * Returns a hash code for this Byte
+						 *
+						 * @param byteValue
+						 * @return int
+						 */
+						static int hashCode(byte byteValue);
+						
+						/**
+						 * Returns the value of this Byte as an int.
+						 *
+						 * @return int
+						 */
+						int intValue() const override;
+						
+						/**
+						 * Returns the value of this Byte as an long.
+						 *
+						 * @return long
+						 */
+						long longValue() const override;
+						
+						/**
+						 * Parse the parameter string as a byte with radix =10
+						 *
+						 * @param stringToParse
+						 * @throw NumberFormatException If the string does not contain a parsable byte.
+						 * @return the byte value represented by the string argument with radix =10
+						 */
+						static byte parseByte(String stringToParse);
+						
+						/**
+						 * Parse the parameter string as a byte
+						 *
+						 * @param stringToParse
+						 * @param radix
+						 * @throw NumberFormatException If the string does not contain a parsable byte.
+						 * @return the byte value represented by the string argument in the specified radix
+						 */
+						static byte parseByte(String stringToParse, int radix);
+						
+						/**
+						 * Returns the value of this Byte as an short.
+						 *
+						 * @return short
+						 */
+						short shortValue() const override;
+						
+						/**
+						 * Returns a string representing this Byte's value
+						 *
+						 * @return string
+						 */
+						string toString() const override;
+						
+						/**
+						 * Returns a new String object representing the specified byte with radix = 10
+						 *
+						 * @param byteValue
+						 * @return String
+						 */
+						static String toString(byte byteValue);
+						
+						/**
+						 * Converts the argument to an int by an unsigned conversion.
+						 *
+						 * @param byteValue
+						 * @return int
+						 */
+						static int toUnsignedInt(byte byteValue);
+						
+						/**
+						 * Converts the argument to an int by an unsigned conversion.
+						 *
+						 * @param byteValue
+						 * @return long
+						 */
+						static long toUnsignedLong(byte byteValue);
+						
+						/**
+						 * Returns a Byte instance representing the specified byte value.
+						 *
+						 * @param byteValue
+						 * @return Byte
+						 */
+						static Byte valueOf(byte byteValue);
+						
+						/**
+						 * Returns a Byte instance representing the specified String value.
+						 *
+						 * @param stringValue
+						 * @return Byte
+						 */
+						static Byte valueOf(String stringValue);
+						
+						/**
+						 * Returns a Byte instance representing the specified String value with radix
+						 *
+						 * @param stringValue
+						 * @param radix
+						 * @return Byte
+						 */
+						static Byte valueOf(String stringValue, int radix);
+				
+				public:
+						/**
+						 * Make a summation with target Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte operator+(const Byte &target);
+						
+						/**
+						 * Make a subtraction with target Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte operator-(const Byte &target);
+						
+						/**
+						 *  Make a division from this Byte with target
+						 *
+						 * @param target
+						 * @throw ArithmeticException if target equal to zero
+						 * @return Byte
+						 */
+						Byte operator/(const Byte &target);
+						
+						/**
+						 * Make a modulo from this Byte with target
+						 *
+						 * @param target
+						 * @throw ArithmeticException if target equal to zero
+						 * @return Byte
+						 */
+						Byte operator%(const Byte &target);
+						
+						/**
+						 * Make a multiplication from this Byte with target
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte operator*(const Byte &target);
+						
+						/**
+						 * Compare 2 Byte
+						 *
+						 * @param target
+						 * @return true if target Byte is equal to this Byte; false otherwise
+						 */
+						boolean operator==(const Byte &target);
+						
+						/**
+						 * Compare 2 Byte
+						 *
+						 * @param target
+						 * @return true if target Byte is not equal to this Byte; false otherwise
+						 */
+						boolean operator!=(const Byte &target);
+						
+						/**
+						 * Determine if this Byte is smaller than target
+						 *
+						 * @param target
+						 * @return true if this Byte is smaller than target; false otherwise
+						 */
+						boolean operator<(const Byte &target);
+						
+						/**
+						 * Determine if this Byte is bigger than target
+						 *
+						 * @param target
+						 * @return true if this Byte is bigger than target; false otherwise
+						 */
+						boolean operator>(const Byte &target);
+						
+						/**
+						 * Determine if this Byte is equal or less than target
+						 *
+						 * @param target
+						 * @return true if this Byte is equal or less than target; false otherwise
+						 */
+						boolean operator<=(const Byte &target);
+						
+						/**
+						 * Determine if this Byte is equal or bigger than target
+						 *
+						 * @param target
+						 * @return true if this Byte is equal or bigger than target; false otherwise
+						 */
+						boolean operator>=(const Byte &target);
+						
+						/**
+						 * Make a subtraction from this Byte with target and assign the result value to this Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte &operator-=(const Byte &target);
+						
+						/**
+						 * Make an summation from this Byte with target and assign the result value to this Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte &operator+=(const Byte &target);
+						
+						/**
+						 * Make a multiplication from this Byte with target and assign the result value to this Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte &operator*=(const Byte &target);
+						
+						/**
+						 * Make a division from this Byte with target and assign the result value to this Byte
+						 *
+						 * @param target
+						 * @return Byte
+						 */
+						Byte &operator/=(const Byte &target);
+						
+						/**
+						 * Make a modulo from this Byte with target and assign the result value to this Byte
+						 *
+						 * @param target
+						 * @throw ArithmeticException if target equal to zero
+						 * @return Byte
+						 */
+						Byte &operator%=(const Byte &target);
+						
+						/**
+						 *  Assign the value of target to this Byte
+						 *
+						 * @param target
+						 * @throw ArithmeticException if target equal to zero
+						 * @return Byte
+						 */
+						Byte &operator=(const Byte &target);
+						
+						inline size_t operator()(const Byte &target) const {
+							String targetString = target.toString();
+							return std::_Hash_impl::hash(targetString.toString(), targetString.length());
+						}
+				};
+				
+				/**
+				 * Byte cache for instance byte
+				 */
+				class ByteCache {
+				private:
+						static ByteCache *instance;
+						
+						ByteCache() {
+							cache = this->cacheInit();
+						};
+						
+						Array<Byte> cache;
+						
+						Array<Byte> cacheInit() {
+							Array<Byte> cacheArray;
+							int index;
+							for (index = 0; index < 256; index++) {
+								cacheArray.push(Byte(static_cast<byte>(index)));
+							}
+							return cacheArray;
+						}
+				
+				public:
+						static ByteCache *getInstance() {
+							if (instance == nullptr) {
+								instance = new ByteCache();
+							}
+							return instance;
+						}
+						
+						Byte getByteAtIndex(int index) {
+							return cache[ index ];
+						}
+				};
+		}
+}
 
-        class Bytes;
-
-		class Bytes :
-                public virtual Number,
-                public virtual Comparable<Bytes> {
-        private:
-			byte original;
-            string originalString;
-
-        public:
-			/**
-			 * Min value of Byte
-			 */
-			static const byte MIN_VALUE = 0;
-
-            /**
-             * Max value of Byte
-             */
-			static const byte MAX_VALUE = 255;
-
-            /**
-             * The number of bits used to represent a byte value in two's complement binary form.
-             */
-			static const int SIZE = 8;
-
-            /**
-             * The number of bytes used to represent a byte value in two's complement binary form.
-             */
-            static constexpr int BYTES = 1;
-
-        public:
-            /**
-             * Default constructor
-             */
-            Bytes();
-
-            /**
-             * Construct a new Byte with the value of byte
-             *
-             * @param byteValue
-             */
-			Bytes(byte byteValue);
-
-            /**
-             * Construct a new Byte with the value of String
-             *
-             * @param inputString
-             * @throw NumberFormatException If inputString does not contain a parsable byte.
-             */
-			Bytes(String inputString);
-
-            /**
-             * Copy constructor
-             *
-             * @param anotherBytes
-             */
-            Bytes(const Bytes &anotherBytes);
-
-			/**
-			 * Destructor, free memory allocated for originalString.
-			 */
-			~Bytes();
-
-		public:
-
-            /**
-             *Return the value of this Byte as a char
-             *
-             * @return char
-             */
-			char charValue() const;
-
-            /**
-             * Byte value
-             *
-             * @return byte
-             */
-            byte byteValue () const;
-
-            /**
-             * Compares two byte values numerically.
-             *
-             * @param byteA
-             * @param byteB
-             * @return the value 0 if byteA == byteB; a value less than 0 if byteA < byteB;
-             * and a value greater than 0 if byteA > byteB
-             */
-			static int compare(byte byteA, byte byteB);
-
-            /**
-             * Compares two Byte objects numerically
-             *
-             * @param other
-             * @return the value 0 if this Byte is equal to other;
-             * a value less than 0 if this Byte is numerically less than other;
-             * and a value greater than 0 if this Byte is numerically greater than other
-             */
-			int compareTo(const Bytes & other) const override;
-
-            /**
-             * Decodes a String into a Byte. Accepts decimal, hexadecimal, and octal numbers
-             *
-             * @param stringToDecode
-             * @throw NumberFormatException - if the String does not contain a parsable byte.
-             * @return a Byte object holding the byte value represented by stringToDecode
-             */
-            static Bytes decode(String stringToDecode);
-
-            /**
-             * Double value of Byte
-             *
-             * @return double
-             */
-			double doubleValue() const override;
-
-			/**
-			 * Compare this Byte to another Byte object
-			 *
-			 * @param object
-			 * @return true if object is a Byte and has the same value as this Bytes; false otherwise
-			 */
-            // TODO need instanceof temporary use Byte instead of Object
-			boolean equals(Bytes object);
-
-            /**
-             * Returns the value of this Byte as an float.
-             *
-             * @return float
-             */
-			float floatValue() const override;
-
-            /**
-             * Returns a hash code for this Byte
-             *
-             * @return long
-             */
-			long hashCode() const override ;
-
-            /**
-             * Returns a hash code for this Byte
-             *
-             * @param byteValue
-             * @return int
-             */
-            static int hashCode(byte byteValue);
-
-            /**
-             * Returns the value of this Byte as an int.
-             *
-             * @return int
-             */
-			int intValue() const override;
-
-            /**
-             * Returns the value of this Byte as an long.
-             *
-             * @return long
-             */
-			long longValue() const override;
-
-            /**
-             * Parse the parameter string as a byte with radix =10
-             *
-             * @param stringToParse
-             * @throw NumberFormatException If the string does not contain a parsable byte.
-             * @return the byte value represented by the string argument with radix =10
-             */
-			static byte parseByte(String stringToParse);
-
-            /**
-             * Parse the parameter string as a byte
-             *
-             * @param stringToParse
-             * @param radix
-             * @throw NumberFormatException If the string does not contain a parsable byte.
-             * @return the byte value represented by the string argument in the specified radix
-             */
-            static byte parseByte(String stringToParse, int radix);
-
-            /**
-             * Returns the value of this Byte as an short.
-             *
-             * @return short
-             */
-			short shortValue() const override;
-
-            /**
-             * Returns a string representing this Byte's value
-             *
-             * @return string
-             */
-			string toString() const override;
-
-            /**
-             * Returns a new String object representing the specified byte with radix = 10
-             *
-             * @param byteValue
-             * @return String
-             */
-			static String toString(byte byteValue);
-
-            /**
-             * Converts the argument to an int by an unsigned conversion.
-             *
-             * @param byteValue
-             * @return int
-             */
-			static int toUnsignedInt(byte byteValue);
-
-            /**
-             * Converts the argument to an int by an unsigned conversion.
-             *
-             * @param byteValue
-             * @return long
-             */
-			static long toUnsignedLong(byte byteValue);
-
-            /**
-             * Returns a Byte instance representing the specified byte value.
-             *
-             * @param byteValue
-             * @return Byte
-             */
-			static Bytes valueOf(byte byteValue);
-
-            /**
-             * Returns a Byte instance representing the specified String value.
-             *
-             * @param stringValue
-             * @return Byte
-             */
-			static Bytes valueOf(String stringValue);
-
-            /**
-             * Returns a Byte instance representing the specified String value with radix
-             *
-             * @param stringValue
-             * @param radix
-             * @return Byte
-             */
-            static Bytes valueOf(String stringValue, int radix);
-
-		public:
-            /**
-             * Make a summation with target Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes operator+(const Bytes &target);
-
-            /**
-             * Make a subtraction with target Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes operator-(const Bytes &target);
-
-            /**
-             *  Make a division from this Byte with target
-             *
-             * @param target
-             * @throw ArithmeticException if target equal to zero
-             * @return Byte
-             */
-			Bytes operator/(const Bytes &target);
-
-            /**
-             * Make a modulo from this Byte with target
-             *
-             * @param target
-             * @throw ArithmeticException if target equal to zero
-             * @return Byte
-             */
-			Bytes operator%(const Bytes &target);
-
-            /**
-             * Make a multiplication from this Byte with target
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes operator*(const Bytes &target);
-
-            /**
-             * Compare 2 Byte
-             *
-             * @param target
-             * @return true if target Byte is equal to this Byte; false otherwise
-             */
-			boolean operator==(const Bytes &target);
-
-            /**
-             * Compare 2 Byte
-             *
-             * @param target
-             * @return true if target Byte is not equal to this Byte; false otherwise
-             */
-			boolean operator!=(const Bytes &target);
-
-            /**
-             * Determine if this Byte is smaller than target
-             *
-             * @param target
-             * @return true if this Byte is smaller than target; false otherwise
-             */
-			boolean operator<(const Bytes &target);
-
-            /**
-             * Determine if this Byte is bigger than target
-             *
-             * @param target
-             * @return true if this Byte is bigger than target; false otherwise
-             */
-			boolean operator>(const Bytes &target);
-
-            /**
-             * Determine if this Byte is equal or less than target
-             *
-             * @param target
-             * @return true if this Byte is equal or less than target; false otherwise
-             */
-			boolean operator<=(const Bytes &target);
-
-            /**
-             * Determine if this Byte is equal or bigger than target
-             *
-             * @param target
-             * @return true if this Byte is equal or bigger than target; false otherwise
-             */
-			boolean operator>=(const Bytes &target);
-
-            /**
-             * Make a subtraction from this Byte with target and assign the result value to this Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes &operator-=(const Bytes &target);
-
-            /**
-             * Make an summation from this Byte with target and assign the result value to this Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes &operator+=(const Bytes &target);
-
-            /**
-             * Make a multiplication from this Byte with target and assign the result value to this Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes &operator*=(const Bytes &target);
-
-            /**
-             * Make a division from this Byte with target and assign the result value to this Byte
-             *
-             * @param target
-             * @return Byte
-             */
-			Bytes &operator/=(const Bytes &target);
-
-            /**
-             * Make a modulo from this Byte with target and assign the result value to this Byte
-             *
-             * @param target
-             * @throw ArithmeticException if target equal to zero
-             * @return Byte
-             */
-			Bytes &operator%=(const Bytes &target);
-
-            /**
-             *  Assign the value of target to this Byte
-             *
-             * @param target
-             * @throw ArithmeticException if target equal to zero
-             * @return Byte
-             */
-            Bytes &operator=(const Bytes &target);
-
-		};
-
-        /**
-         * Byte cache for instance byte
-         */
-        class ByteCache {
-        private:
-            static ByteCache *instance;
-
-            ByteCache() {
-                cache = this->cacheInit();
-            };
-
-            Array<Bytes> cache;
-
-            Array<Bytes> cacheInit() {
-                Array<Bytes> cacheArray;
-                int index;
-                for (index = 0; index < 256; index++) {
-					cacheArray.push(Bytes(static_cast<byte>(index)));
+namespace std {
+		template <>
+		struct hash<Byte> {
+				std::size_t operator()(const Byte &k) const {
+					return Byte()(k);
 				}
-                return cacheArray;
-            }
-
-        public:
-            static ByteCache *getInstance() {
-                if (instance == nullptr)
-                    instance = new ByteCache();
-                return instance;
-            }
-
-            Bytes getByteAtIndex(int index) {
-                return cache[index];
-            }
-        };
-	}
+		};
 }
 #endif

--- a/java/lang/Byte/ByteTest.cpp
+++ b/java/lang/Byte/ByteTest.cpp
@@ -33,13 +33,13 @@ using namespace Java::Lang;
 
 TEST(JavaLang, ByteConstructor) {
 	// Given empty value for Byte constructor and assign value - Return Byte
-    Bytes defaultConstructorByte;
+    Byte defaultConstructorByte;
     int expectResult = 0;
     int actualByteValue = defaultConstructorByte.intValue();
     assertEquals(expectResult, actualByteValue);
     assertEquals("0", defaultConstructorByte.toString());
 
-	Bytes byteConstructorByte = Bytes(3);
+	Byte byteConstructorByte = Byte(3);
     expectResult = 3;
     actualByteValue = byteConstructorByte.intValue();
 	assertEquals(expectResult, actualByteValue);
@@ -47,40 +47,40 @@ TEST(JavaLang, ByteConstructor) {
 
 
     // Constructor with String
-    Bytes stringConstructorByte = Bytes("3");
+    Byte stringConstructorByte = Byte("3");
     actualByteValue = stringConstructorByte.intValue();
     assertEquals(expectResult, actualByteValue);
     assertEquals("3", stringConstructorByte.toString());
 
     // Copy constructor
-    Bytes copyConstructorByte = Bytes(stringConstructorByte);
+    Byte copyConstructorByte = Byte(stringConstructorByte);
     actualByteValue = copyConstructorByte.intValue();
     assertEquals(expectResult, actualByteValue);
     assertEquals("3", copyConstructorByte.toString());
 
     try {
-        Bytes exceptionByte = Bytes("");
+        Byte exceptionByte = Byte("");
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes("abcd");
+        Byte exceptionByte = Byte("abcd");
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes("999999999999");
+        Byte exceptionByte = Byte("999999999999");
     }
     catch (NumberFormatException &e) {
         assertEquals("Integer out of range", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes("256");
+        Byte exceptionByte = Byte("256");
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -89,7 +89,7 @@ TEST(JavaLang, ByteConstructor) {
 
 TEST(JavaLang, ByteCharValue) {
     // Given a char and a Byte with the same value to compare the result of charValue()
-    Bytes byteToGetValue = 'a';
+    Byte byteToGetValue = 'a';
     char expectResult = 'a';
     char actualResult = byteToGetValue.charValue();
     assertEquals(expectResult,actualResult);
@@ -97,7 +97,7 @@ TEST(JavaLang, ByteCharValue) {
 
 TEST(JavaLang, ByteByteValue) {
     // Given a byte and a Byte with the same value to compare the result of charValue()
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     byte expectResult = 5;
     byte actualResult = byteToGetValue.byteValue();
     assertEquals(expectResult, actualResult);
@@ -105,61 +105,61 @@ TEST(JavaLang, ByteByteValue) {
 
 TEST(JavaLang, ByteCompareTo) {
     // Given 3 Byte
-    Bytes firstBytes = 1;
-    Bytes secondBytes = 1;
-    Bytes thirdBytes = 3;
+    Byte firstByte = 1;
+    Byte secondByte = 1;
+    Byte thirdByte = 3;
 
     // Compare
-    assertEquals(0, firstBytes.compareTo(secondBytes));
-    assertTrue(firstBytes.compareTo(thirdBytes) < 0);
-    assertTrue(thirdBytes.compareTo(firstBytes) > 0);
+    assertEquals(0, firstByte.compareTo(secondByte));
+    assertTrue(firstByte.compareTo(thirdByte) < 0);
+    assertTrue(thirdByte.compareTo(firstByte) > 0);
 
-    Comparable<Bytes> *comparable = &secondBytes;
-    assertEquals(0, comparable->compareTo(firstBytes));
+    Comparable<Byte> *comparable = &secondByte;
+    assertEquals(0, comparable->compareTo(firstByte));
 }
 
 TEST(JavaLang, ByteDecode) {
     // Given a decimal value are decode and assigned to decByte
-    Bytes decByte = Bytes::decode("100");
+    Byte decByte = Byte::decode("100");
     byte expectDecResult = 100;
     byte actualDecResult = decByte.byteValue();
     assertEquals(expectDecResult, actualDecResult);
 
     // Given a hexadecimal values are decoded and assigned to hexByte
-    Bytes hexByte = Bytes::decode("0x6b");
+    Byte hexByte = Byte::decode("0x6b");
     byte expectHexResult = 107;
     byte actualHexResult = hexByte.byteValue();
     assertEquals(expectHexResult, actualHexResult);
 
     // Given an octal value is decoded and assigned to octalByte
-    Bytes octalByte = Bytes::decode("0127");
+    Byte octalByte = Byte::decode("0127");
     byte expectOctalResult = 87;
     byte actualOctalResult = octalByte.byteValue();
     assertEquals(expectOctalResult, actualOctalResult);
 
     try {
-        Bytes exceptionByte = Bytes::decode("");
+        Byte exceptionByte = Byte::decode("");
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::decode("abcd");
+        Byte exceptionByte = Byte::decode("abcd");
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::decode("999999999999");
+        Byte exceptionByte = Byte::decode("999999999999");
     }
     catch (NumberFormatException &e) {
         assertEquals("Integer out of range", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::decode("256");
+        Byte exceptionByte = Byte::decode("256");
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -168,28 +168,28 @@ TEST(JavaLang, ByteDecode) {
 
 TEST(JavaLang, ByteDoubleValue) {
     // Given a Double and a Byte with the same value
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     double expectResult = 5;
     double actualResult = byteToGetValue.doubleValue();
     assertEquals(expectResult, actualResult);
 }
 
 TEST(JavaLang, ByteByteEquals) {
-    // Given 3 Bytes
-    Bytes firstBytes = 1;
-    Bytes secondBytes = 1;
-    Bytes thirdBytes = 3;
+    // Given 3 Byte
+    Byte firstByte = 1;
+    Byte secondByte = 1;
+    Byte thirdByte = 3;
 
-    assertTrue(firstBytes.equals(secondBytes));
-    assertFalse(firstBytes.equals(thirdBytes));
-    /*// Test Bytes and Object
+    assertTrue(firstByte.equals(secondByte));
+    assertFalse(firstByte.equals(thirdByte));
+    /*// Test Byte and Object
     Object object;
-    assertFalse(firstBytes.equals(object));*/
+    assertFalse(firstByte.equals(object));*/
 }
 
 TEST(JavaLang, ByteFloatValue) {
     // Given a float and a Byte with the same value
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     float expectResult = 5;
     float actualResult = byteToGetValue.floatValue();
     assertEquals(expectResult, actualResult);
@@ -197,7 +197,7 @@ TEST(JavaLang, ByteFloatValue) {
 
 TEST(JavaLang, ByteHashCode ) {
     // Given a Byte
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     long expectResult = 5;
     long actualResult = byteToGetValue.hashCode();
     assertEquals(expectResult, actualResult);
@@ -205,7 +205,7 @@ TEST(JavaLang, ByteHashCode ) {
 
 TEST(JavaLang, ByteIntValue) {
     // Given a int and a Byte with the same value
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     int expectResult = 5;
     int actualResult = byteToGetValue.intValue();
     assertEquals(expectResult, actualResult);
@@ -213,7 +213,7 @@ TEST(JavaLang, ByteIntValue) {
 
 TEST(JavaLang, ByteLongValue) {
     // Given a int and a Byte with the same value
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     long expectResult = 5;
     long actualResult = byteToGetValue.longValue();
     assertEquals(expectResult, actualResult);
@@ -222,33 +222,33 @@ TEST(JavaLang, ByteLongValue) {
 TEST(JavaLang, ByteParseByte) {
     // Assign value 20 to resultByte from a String using parseByte
     byte expectResult = 20;
-    byte actualResult = Bytes::parseByte("20");
+    byte actualResult = Byte::parseByte("20");
     // need parseByte(string)
     assertEquals(expectResult, actualResult);
 
     try {
-        Bytes exceptionByte = Bytes::parseByte("");
+        Byte exceptionByte = Byte::parseByte("");
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::parseByte("abcd");
+        Byte exceptionByte = Byte::parseByte("abcd");
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::parseByte("999999999999");
+        Byte exceptionByte = Byte::parseByte("999999999999");
     }
     catch (NumberFormatException &e) {
         assertEquals("Integer out of range", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::parseByte("256");
+        Byte exceptionByte = Byte::parseByte("256");
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -259,44 +259,44 @@ TEST(JavaLang, ByteParseByteWithRadix) {
 
     // Assign value 20 to resultByte from a String using parseByte with radix =10
     byte expectResult = 20;
-    byte actualResult = Bytes::parseByte("+20", 10);
+    byte actualResult = Byte::parseByte("+20", 10);
     assertEquals(expectResult, actualResult);
 
     expectResult = 0;
-    actualResult = Bytes::parseByte("0", 15);
+    actualResult = Byte::parseByte("0", 15);
     assertEquals(expectResult, actualResult);
 
     expectResult = 255;
-    actualResult = Bytes::parseByte("FF", 16);
+    actualResult = Byte::parseByte("FF", 16);
     assertEquals(expectResult, actualResult);
 
     expectResult = 102;
-    actualResult = Bytes::parseByte("1100110", 2);
+    actualResult = Byte::parseByte("1100110", 2);
     assertEquals(expectResult, actualResult);
 
     try {
-        expectResult = Bytes::parseByte((String) "99", 8);
+        expectResult = Byte::parseByte((String) "99", 8);
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        expectResult = Bytes::parseByte((String) "Kona", 33);
+        expectResult = Byte::parseByte((String) "Kona", 33);
     }
     catch (NumberFormatException &e) {
         assertEquals("radix out of range", e.getMessage().toString());
     }
 
     try {
-        expectResult = Bytes::parseByte((String) "", 2);
+        expectResult = Byte::parseByte((String) "", 2);
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::parseByte("256", 10);
+        Byte exceptionByte = Byte::parseByte("256", 10);
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -305,7 +305,7 @@ TEST(JavaLang, ByteParseByteWithRadix) {
 
 TEST(JavaLang, ByteShortValue) {
     // Given a short and a Byte with the same value
-    Bytes byteToGetValue = 5;
+    Byte byteToGetValue = 5;
     short expectResult = 5;
     short actualResult = byteToGetValue.shortValue();
     assertEquals(expectResult, actualResult);
@@ -313,7 +313,7 @@ TEST(JavaLang, ByteShortValue) {
 
 TEST(JavaLang, ByteToString) {
     // Given a string and a Byte with the same value
-    Bytes byteToGetValue = 2;
+    Byte byteToGetValue = 2;
     string expectResult = (string) "2";
     string actualResult = byteToGetValue.toString();
     assertEquals(expectResult, actualResult);
@@ -323,48 +323,48 @@ TEST(JavaLang, ByteToStringWithByte) {
     // Given a string and a Byte with the same value
     byte byteToRepresent = 2;
     String expectResult = "2";
-    String actualResult = Bytes::toString(byteToRepresent);
+    String actualResult = Byte::toString(byteToRepresent);
     assertEquals(expectResult.toString(), actualResult.toString());
 }
 
 TEST(JavaLang, ByteValueOfByte) {
     // Given a byte and a Byte, then assign value to Byte using valueOf(byte)
     byte byteToGetValue = 50;
-    Bytes expectResult = Bytes(50);
-    Bytes actualResult = Bytes::valueOf(byteToGetValue);
+    Byte expectResult = Byte(50);
+    Byte actualResult = Byte::valueOf(byteToGetValue);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 }
 
 TEST(JavaLang, ByteValueOfString) {
     // Given a byte and a Byte, then assign value to Byte using valueOf(byte)
     String stringToGetValue = "50";
-    Bytes expectResult = Bytes(static_cast<byte>(50));
-    Bytes actualResult = Bytes::valueOf(stringToGetValue);
+    Byte expectResult = Byte(static_cast<byte>(50));
+    Byte actualResult = Byte::valueOf(stringToGetValue);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 
     try {
-        Bytes exceptionByte = Bytes::valueOf("");
+        Byte exceptionByte = Byte::valueOf("");
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::valueOf("abcd");
+        Byte exceptionByte = Byte::valueOf("abcd");
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::valueOf("999999999999");
+        Byte exceptionByte = Byte::valueOf("999999999999");
     }
     catch (NumberFormatException &e) {
         assertEquals("Integer out of range", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::valueOf("256");
+        Byte exceptionByte = Byte::valueOf("256");
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -374,45 +374,45 @@ TEST(JavaLang, ByteValueOfString) {
 TEST(JavaLang, ByteValueOfStringWithRadix) {
     // Given a byte and a Byte, then assign value to Byte using valueOf(byte)
     String byteToGetValue = "50";
-    Bytes expectResult = Bytes(50);
-    Bytes actualResult = Bytes::valueOf(byteToGetValue, 10);
+    Byte expectResult = Byte(50);
+    Byte actualResult = Byte::valueOf(byteToGetValue, 10);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 
     expectResult = 0;
-    actualResult = Bytes::valueOf("0", 15);
+    actualResult = Byte::valueOf("0", 15);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 
     expectResult = 255;
-    actualResult = Bytes::valueOf("FF", 16);
+    actualResult = Byte::valueOf("FF", 16);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 
     expectResult = 102;
-    actualResult = Bytes::valueOf("1100110", 2);
+    actualResult = Byte::valueOf("1100110", 2);
     assertEquals(expectResult.intValue(), actualResult.intValue());
 
     try {
-        expectResult = Bytes::valueOf((String) "99", 8);
+        expectResult = Byte::valueOf((String) "99", 8);
     }
     catch (NumberFormatException &e) {
         assertEquals("Not a number", e.getMessage().toString());
     }
 
     try {
-        expectResult = Bytes::valueOf((String) "Kona", 33);
+        expectResult = Byte::valueOf((String) "Kona", 33);
     }
     catch (NumberFormatException &e) {
         assertEquals("radix out of range", e.getMessage().toString());
     }
 
     try {
-        expectResult = Bytes::valueOf((String) "", 2);
+        expectResult = Byte::valueOf((String) "", 2);
     }
     catch (NumberFormatException &e) {
         assertEquals("input string is null", e.getMessage().toString());
     }
 
     try {
-        Bytes exceptionByte = Bytes::valueOf("256", 10);
+        Byte exceptionByte = Byte::valueOf("256", 10);
     }
     catch (NumberFormatException &e) {
         assertEquals("out of byte range", e.getMessage().toString());
@@ -422,7 +422,7 @@ TEST(JavaLang, ByteValueOfStringWithRadix) {
 TEST(JavaLang, ByteHashCodeWithByte) {
     byte byteToGetValue = 5;
     int expectResult = 5;
-    int actualResult = Bytes::hashCode(byteToGetValue);
+    int actualResult = Byte::hashCode(byteToGetValue);
     assertEquals(expectResult, actualResult);
 }
 
@@ -431,48 +431,48 @@ TEST(JavaLang, ByteCompare) {
     byte byte2 = 10;
     byte byte3 = 5;
     // Return a value < 0 if a < b
-    assertTrue(Bytes::compare(byte1, byte2) < 0);
+    assertTrue(Byte::compare(byte1, byte2) < 0);
     // Return a value > 0 if a > b
-    assertTrue(Bytes::compare(byte2, byte1) > 0);
+    assertTrue(Byte::compare(byte2, byte1) > 0);
     // Return a value = 0 if a < b
-    assertEquals(0, Bytes::compare(byte1, byte3));
+    assertEquals(0, Byte::compare(byte1, byte3));
 }
 
 TEST(JavaLang, ByteToUnsignedInt) {
     byte byteToGetValue = static_cast<byte>(-5);
     int expectResult = 251;
-    int actualResult = Bytes::toUnsignedInt(byteToGetValue);
+    int actualResult = Byte::toUnsignedInt(byteToGetValue);
     assertEquals(expectResult, actualResult);
 }
 
 TEST(JavaLang, ByteToUnsignedLong) {
     byte byteToGetValue = static_cast<byte>(-5);
     long expectResult = 251;
-    long actualResult = Bytes::toUnsignedLong(byteToGetValue);
+    long actualResult = Byte::toUnsignedLong(byteToGetValue);
     assertEquals(expectResult, actualResult);
 }
 
 TEST(JavaLang, ByteByteOperator) {
 	// Given a valid number
-	Bytes validByte = 5;
-	Bytes targetByte = 3;
-    Bytes equalValidByte = 5;
-    Bytes zeroByte = 0;
+	Byte validByte = 5;
+	Byte targetByte = 3;
+    Byte equalValidByte = 5;
+    Byte zeroByte = 0;
 	
 	// Make a summation with targetByte
-	Bytes summationByte = 8;
+	Byte summationByte = 8;
 	assertTrue(summationByte == (validByte + targetByte));
 	
 	// Make a subtraction with targetByte
-	Bytes subtractionByte = 2;
+	Byte subtractionByte = 2;
 	assertTrue(subtractionByte == (validByte - targetByte));
 	
 	// Make a multiplication with targetByte
-	Bytes multiplicationByte = 15;
+	Byte multiplicationByte = 15;
 	assertTrue(multiplicationByte == (validByte * targetByte));
 	
 	// Make a division with targetByte
-	Bytes divisionByte = 1;
+	Byte divisionByte = 1;
 	assertTrue(divisionByte == (validByte / targetByte));
 
     try {
@@ -483,7 +483,7 @@ TEST(JavaLang, ByteByteOperator) {
     }
 	
 	// Make a modulo with targetByte
-	Bytes modulusByte = 2;
+	Byte modulusByte = 2;
 	assertTrue(modulusByte == (validByte % targetByte));
 
     try {

--- a/java/lang/Double/Double.hpp
+++ b/java/lang/Double/Double.hpp
@@ -33,456 +33,456 @@
 #include "../Math/Math.hpp"
 
 namespace Java {
-    namespace Lang {
-        class Double : public Number {
-        public:
-            /**
-             * The number of logical bits in the significand of a double number,
-             * including the implicit bit.
-             */
-            static const int SIGNIFICAND_WIDTH = 53;
-
-            /**
-             * Maximum exponent a finite double number may have.
-             */
-            static const int MAX_EXPONENT = 1023;
-
-            /**
-             * Minimum exponent a normalized double number may have.
-             */
-            static const int MIN_EXPONENT = -1022;
-
-            /**
-             * The exponent the smallest positive double subnormal value would have
-             * if it could be normalized.
-             */
-            static constexpr int MIN_SUB_EXPONENT = MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
-
-            /**
-             * Bias used in representing a double exponent.
-             */
-            static const int EXP_BIAS = 1023;
-
-            /**
-             * Bit mask to isolate the sign bit of a double.
-             */
-            static const long SIGN_BIT_MASK = 0x8000000000000000L;
-
-            /**
-             * Bit mask to isolate the exponent field of a double.
-             */
-            static const long EXP_BIT_MASK = 0x7FF0000000000000L;
-
-            /**
-             * Bit mask to isolate the significand field of a double.
-             */
-            static const long SIGNIF_BIT_MASK = 0x000FFFFFFFFFFFFFL;
-
-            /**
-             * A constant holding the positive infinity of type
-             */
-            static constexpr double POSITIVE_INFINITY = INFINITY;  // inf
-
-            /**
-             * A constant holding the negative infinity of type
-             */
-            static constexpr double NEGATIVE_INFINITY = -INFINITY;  // -inf
-
-            /**
-             * A constant holding a Not-a-Number (NaN) value of type
-             */
-            static constexpr double NaN = NAN;  // -nan
-
-            /**
-             * A constant holding the largest positive finite value of type
-             */
-            static constexpr double MAX_VALUE = std::numeric_limits<double>::max();
-            /**
-             * A constant holding the smallest positive normal value of type
-             */
-            static constexpr double MIN_NORMAL = std::numeric_limits<double>::denorm_min();  // 2.225073858507201e-308
-
-            /**
-             * A constant holding the smallest positive nonzero value of type
-             */
-            static constexpr double MIN_VALUE = std::numeric_limits<double>::min();  // 4.940656458412465e-324
-
-        public:
-            Double();
-
-            Double(double original);
-
-            Double(const Double &target);
-
-            ~Double();
-
-        public:
-            /**
-             * Adds two operands
-             *
-             * @return Double
-             */
-            Double operator+(const Double &target);
-
-            /**
-             * Subtracts second operand from the first
-             *
-             * @return Double
-             */
-            Double operator-(const Double &target);
-
-            /**
-             *  Multiplies both operands
-             *
-             * @return Double
-             */
-            Double operator*(const Double &target);
-
-            /**
-             * Divides numerator by de-numerator
-             *
-             * @return Double
-             */
-            Double operator/(const Double &target);
-
-            /**
-             * Checks if the values of two operands
-             * are equal or not,
-             *
-             * @return boolean
-             */
-            boolean operator==(const Double &target) const;
-
-            /**
-             * Checks if the values of two operands
-             * are equal or not,
-             *
-             * @return boolean
-             */
-            boolean operator!=(const Double &target) const;
-
-            /**
-             * Checks if the value of left operand
-             * is greater than the value of right operand
-             *
-             * @return boolean
-             */
-            boolean operator>(const Double &target) const;
-
-            /**
-             * Checks if the value of left operand
-             * is less than the value of right operand,
-             *
-             * @return boolean
-             */
-            boolean operator<(const Double &target) const;
-
-            /**
-             * Checks if the value of left operand
-             * is greater than or equal to the value of right operand,
-             *
-             * @return boolean
-             */
-            boolean operator>=(const Double &target) const;
-
-            /**
-             *  Checks if the value of left operand
-             *  is less than or equal to the value of right operand,
-             *
-             * @return boolean
-             */
-            boolean operator<=(const Double &target) const;
-
-            /**
-             *  Called Logical AND operator.
-             *  If both the operands are non-zero
-             *
-             * @return boolean
-             */
-            boolean operator&&(const Double &target) const;
-
-            /**
-             *  Called Logical OR Operator.
-             *  If any of the two operands is non-zero
-             *
-             * @return boolean
-             */
-            boolean operator||(const Double &target) const;
-
-            /**
-             * Simple assignment operator,
-             * Assigns values from right side operands
-             * to left side operand
-             *
-             * @param target
-             * @return Double
-             */
-            Double &operator=(const Double &target);
-
-            /**
-             * Add AND assignment operator,
-             * It adds right operand to the left operand
-             * and assign the result to left operand
-             *
-             * @param target
-             * @return Double
-             */
-            Double operator+=(const Double &target) const;
-
-            /**
-             * Subtract AND assignment operator,
-             * It subtracts right operand from the left operand
-             * and assign the result to left operand
-             *
-             * @param target
-             * @return Double
-             */
-            Double operator-=(const Double &target) const;
-
-            /**
-             * Multiply AND assignment operator,
-             * It multiplies right operand with the left operand
-             * and assign the result to left operand
-             *
-             * @param target
-             * @return Double
-             */
-            Double operator*=(const Double &target) const;
-
-            /**
-             * Divide AND assignment operator,
-             * It divides left operand with the right operand
-             * and assign the result to left operand
-             *
-             * @param target
-             * @return Double
-             */
-            Double operator/=(const Double &target) const;
-
-            /**
-             * Double to Char
-             *
-             * @return char
-             */
-            char charValue() const;
-
-            /**
-             * Short value of Double
-             *
-             * @return short
-             */
-            short shortValue() const override;
-
-            /**
-             * Double value in Double
-             *
-             * @return int
-             */
-            int intValue() const override;
-
-            /**
-             * Double value in Long
-             *
-             * @return long
-             */
-            long longValue() const override;
-
-            /**
-             * Double value in float
-             *
-             * @return float
-             */
-            float floatValue() const override;
-
-            /**
-             * Double value in double
-             *
-             * @return double
-             */
-            double doubleValue() const override;
-
-            /**
-             * Double to String
-             *
-             * @return String
-             */
-            string toString() const override;
-
-            /**
-             * Returns a string representation of the double
-             * argument. All characters mentioned below are ASCII characters.
-             *
-             * @param d the double to be converted.
-             * @return a string representation of the argument.
-             */
-            static String toString(double d);
-
-            /**
-             * Parse double
-             *
-             * @param target
-             * @return double
-             */
-            static Double parseDouble(String target);
-
-            /**
-             * Returns the value of this {Double} as a {byte}
-             * after a narrowing primitive conversion.
-             *
-             * @return  the double value represented by this object
-             *          converted to type {byte}
-             */
-            byte byteValue() const;
-
-            /**
-             * Compares the two specified double values. The sign
-             * of the integer value returned is the same as that of the
-             * integer that would be returned by the call:
-             *    Double(double1).compareTo(Double(d2))
-             *
-             * @param   double1        the first double to compare
-             * @param   double2        the second double to compare
-             * @return  the value {0} if {double1} is
-             *          numerically equal to {double2}; a value less than
-             *          {0} if {double1} is numerically less than
-             *          {double2}; and a value greater than {0}
-             *          if {double1} is numerically greater than
-             *          {double2}.
-             */
-            static int compare(double double1, double double2);
-
-            /**
-             * Compares two {Double} objects numerically.
-             *
-             * @param   anotherDouble   the {Double} to be compared.
-             * @return  the value {0} if {anotherDouble} is
-             *          numerically equal to this {Double}; a value
-             *          less than {0} if this {Double}
-             *          is numerically less than {anotherDouble};
-             *          and a value greater than {0} if this
-             *          {Double} is numerically greater than
-             *          {anotherDouble}.
-             */
-            int compareTo(Double anotherDouble);
-
-            /**
-             * Returns a representation of the specified floating-point value
-             * according to the IEEE 754 floating-point "double
-             * format" bit layout.
-             *
-             * @param   value   a double precision floating-point number.
-             * @return the bits that represent the floating-point number.
-             */
-            static long doubleToLongBits(double valueDouble);
-
-            /**
-             * Returns a representation of the specified floating-point value
-             * according to the IEEE 754 floating-point "double
-             * format" bit layout, preserving Not-a-Number (NaN) values.
-             *
-             * @param   value   a double precision floating-point number.
-             * @return the bits that represent the floating-point number.
-             */
-            static long doubleToRawLongBits(double doubleInput);
-
-            /**
-             * Compares this object against the specified object.
-             *
-             * @param   obj   the object to compare with.
-             * @return  {true} if the objects are the same;
-             *          {false} otherwise.
-             * @see java.lang.Double#doubleToLongBits(double)
-             */
-            boolean equals(const Double &object) const;
-
-            /**
-             * Returns a hash code for this {Double} object.
-             *
-             * @return  a {hash code} value for this object.
-             */
-            long hashCode();
-
-            /**
-             * Returns a hash code for a double value; compatible with
-             * {Double.hashCode()}.
-             *
-             * @param value the value to hash
-             * @return a hash code value for a double value.
-             */
-            static long hashCode(double doubleInput);
-
-            /**
-             * Returns {true} if the argument is a finite floating-point
-             * value; returns {false} otherwise (for NaN and infinity
-             * arguments).
-             *
-             * @param d the double value to be tested
-             * @return {true} if the argument is a finite
-             * floating-point value, {false} otherwise.
-             */
-            static boolean isFinite(double d);
-
-            /**
-             * Returns {true} if the specified number is infinitely
-             * large in magnitude, {false} otherwise.
-             *
-             * @param   v   the value to be tested.
-             * @return  {true} if the value of the argument is positive
-             *          infinity or negative infinity; {false} otherwise.
-             */
-            static boolean isInfinite(double v);
-
-            /**
-            * Returns {true} if this {Double} value is
-            * infinitely large in magnitude, {false} otherwise.
-            *
-            * @return  {true} if the value represented by this object is
-            *          positive infinity or negative infinity;
-            *          {false} otherwise.
-            */
-            boolean isInfinite();
-
-            /**
-             * Returns {true} if the specified number is a
-             * Not-a-Number (NaN) value, {false} otherwise.
-             *
-             * @param   v   the value to be tested.
-             * @return  {true} if the value of the argument is NaN;
-             *          {false} otherwise.
-             */
-            static boolean isNaN(double v);
-
-            /**
-             * Returns {true} if this {Double} value is
-             * a Not-a-Number (NaN), {false} otherwise.
-             *
-             * @return  {true} if the value represented by this object is
-             *          NaN; {false} otherwise.
-             */
-            boolean isNaN();
-
-            /**
-             * Returns the double value corresponding to a given
-             * bit representation.
-             *
-             * @param   bits   any {long} integer.
-             * @return  the double floating-point value with the same
-             *          bit pattern.
-             */
-            static double longBitsToDouble(long bits);
-
-            /**
-             * Returns the smaller of two double values
-             * as if by calling {@link Math#min(double, double) Math.min}.
-             *
-             * @param a the first operand
-             * @param b the second operand
-             * @return the smaller of {a} and {b}.
-             * @see java.util.function.BinaryOperator
-             */
-            static double min(double a, double b);
-
-            // TODO(thoangminh): Implement later
+		namespace Lang {
+				class Double : public Number {
+				public:
+						/**
+						 * The number of logical bits in the significand of a double number,
+						 * including the implicit bit.
+						 */
+						static const int SIGNIFICAND_WIDTH = 53;
+						
+						/**
+						 * Maximum exponent a finite double number may have.
+						 */
+						static const int MAX_EXPONENT = 1023;
+						
+						/**
+						 * Minimum exponent a normalized double number may have.
+						 */
+						static const int MIN_EXPONENT = -1022;
+						
+						/**
+						 * The exponent the smallest positive double subnormal value would have
+						 * if it could be normalized.
+						 */
+						static constexpr int MIN_SUB_EXPONENT = MIN_EXPONENT - ( SIGNIFICAND_WIDTH - 1 );
+						
+						/**
+						 * Bias used in representing a double exponent.
+						 */
+						static const int EXP_BIAS = 1023;
+						
+						/**
+						 * Bit mask to isolate the sign bit of a double.
+						 */
+						static const long SIGN_BIT_MASK = 0x8000000000000000L;
+						
+						/**
+						 * Bit mask to isolate the exponent field of a double.
+						 */
+						static const long EXP_BIT_MASK = 0x7FF0000000000000L;
+						
+						/**
+						 * Bit mask to isolate the significand field of a double.
+						 */
+						static const long SIGNIF_BIT_MASK = 0x000FFFFFFFFFFFFFL;
+						
+						/**
+						 * A constant holding the positive infinity of type
+						 */
+						static constexpr double POSITIVE_INFINITY = INFINITY;  // inf
+						
+						/**
+						 * A constant holding the negative infinity of type
+						 */
+						static constexpr double NEGATIVE_INFINITY = -INFINITY;  // -inf
+						
+						/**
+						 * A constant holding a Not-a-Number (NaN) value of type
+						 */
+						static constexpr double NaN = NAN;  // -nan
+						
+						/**
+						 * A constant holding the largest positive finite value of type
+						 */
+						static constexpr double MAX_VALUE = std::numeric_limits<double>::max();
+						/**
+						 * A constant holding the smallest positive normal value of type
+						 */
+						static constexpr double MIN_NORMAL = std::numeric_limits<double>::denorm_min();  // 2.225073858507201e-308
+						
+						/**
+						 * A constant holding the smallest positive nonzero value of type
+						 */
+						static constexpr double MIN_VALUE = std::numeric_limits<double>::min();  // 4.940656458412465e-324
+				
+				public:
+						Double();
+						
+						Double(double original);
+						
+						Double(const Double &target);
+						
+						~Double();
+				
+				public:
+						/**
+						 * Adds two operands
+						 *
+						 * @return Double
+						 */
+						Double operator+(const Double &target);
+						
+						/**
+						 * Subtracts second operand from the first
+						 *
+						 * @return Double
+						 */
+						Double operator-(const Double &target);
+						
+						/**
+						 *  Multiplies both operands
+						 *
+						 * @return Double
+						 */
+						Double operator*(const Double &target);
+						
+						/**
+						 * Divides numerator by de-numerator
+						 *
+						 * @return Double
+						 */
+						Double operator/(const Double &target);
+						
+						/**
+						 * Checks if the values of two operands
+						 * are equal or not,
+						 *
+						 * @return boolean
+						 */
+						boolean operator==(const Double &target) const;
+						
+						/**
+						 * Checks if the values of two operands
+						 * are equal or not,
+						 *
+						 * @return boolean
+						 */
+						boolean operator!=(const Double &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is greater than the value of right operand
+						 *
+						 * @return boolean
+						 */
+						boolean operator>(const Double &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is less than the value of right operand,
+						 *
+						 * @return boolean
+						 */
+						boolean operator<(const Double &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is greater than or equal to the value of right operand,
+						 *
+						 * @return boolean
+						 */
+						boolean operator>=(const Double &target) const;
+						
+						/**
+						 *  Checks if the value of left operand
+						 *  is less than or equal to the value of right operand,
+						 *
+						 * @return boolean
+						 */
+						boolean operator<=(const Double &target) const;
+						
+						/**
+						 *  Called Logical AND operator.
+						 *  If both the operands are non-zero
+						 *
+						 * @return boolean
+						 */
+						boolean operator&&(const Double &target) const;
+						
+						/**
+						 *  Called Logical OR Operator.
+						 *  If any of the two operands is non-zero
+						 *
+						 * @return boolean
+						 */
+						boolean operator||(const Double &target) const;
+						
+						/**
+						 * Simple assignment operator,
+						 * Assigns values from right side operands
+						 * to left side operand
+						 *
+						 * @param target
+						 * @return Double
+						 */
+						Double &operator=(const Double &target);
+						
+						/**
+						 * Add AND assignment operator,
+						 * It adds right operand to the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param target
+						 * @return Double
+						 */
+						Double operator+=(const Double &target) const;
+						
+						/**
+						 * Subtract AND assignment operator,
+						 * It subtracts right operand from the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param target
+						 * @return Double
+						 */
+						Double operator-=(const Double &target) const;
+						
+						/**
+						 * Multiply AND assignment operator,
+						 * It multiplies right operand with the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param target
+						 * @return Double
+						 */
+						Double operator*=(const Double &target) const;
+						
+						/**
+						 * Divide AND assignment operator,
+						 * It divides left operand with the right operand
+						 * and assign the result to left operand
+						 *
+						 * @param target
+						 * @return Double
+						 */
+						Double operator/=(const Double &target) const;
+						
+						/**
+						 * Double to Char
+						 *
+						 * @return char
+						 */
+						char charValue() const;
+						
+						/**
+						 * Short value of Double
+						 *
+						 * @return short
+						 */
+						short shortValue() const override;
+						
+						/**
+						 * Double value in Double
+						 *
+						 * @return int
+						 */
+						int intValue() const override;
+						
+						/**
+						 * Double value in Long
+						 *
+						 * @return long
+						 */
+						long longValue() const override;
+						
+						/**
+						 * Double value in float
+						 *
+						 * @return float
+						 */
+						float floatValue() const override;
+						
+						/**
+						 * Double value in double
+						 *
+						 * @return double
+						 */
+						double doubleValue() const override;
+						
+						/**
+						 * Double to String
+						 *
+						 * @return String
+						 */
+						string toString() const override;
+						
+						/**
+						 * Returns a string representation of the double
+						 * argument. All characters mentioned below are ASCII characters.
+						 *
+						 * @param d the double to be converted.
+						 * @return a string representation of the argument.
+						 */
+						static String toString(double d);
+						
+						/**
+						 * Parse double
+						 *
+						 * @param target
+						 * @return double
+						 */
+						static Double parseDouble(String target);
+						
+						/**
+						 * Returns the value of this {Double} as a {byte}
+						 * after a narrowing primitive conversion.
+						 *
+						 * @return  the double value represented by this object
+						 *          converted to type {byte}
+						 */
+						byte byteValue() const;
+						
+						/**
+						 * Compares the two specified double values. The sign
+						 * of the integer value returned is the same as that of the
+						 * integer that would be returned by the call:
+						 *    Double(double1).compareTo(Double(d2))
+						 *
+						 * @param   double1        the first double to compare
+						 * @param   double2        the second double to compare
+						 * @return  the value {0} if {double1} is
+						 *          numerically equal to {double2}; a value less than
+						 *          {0} if {double1} is numerically less than
+						 *          {double2}; and a value greater than {0}
+						 *          if {double1} is numerically greater than
+						 *          {double2}.
+						 */
+						static int compare(double double1, double double2);
+						
+						/**
+						 * Compares two {Double} objects numerically.
+						 *
+						 * @param   anotherDouble   the {Double} to be compared.
+						 * @return  the value {0} if {anotherDouble} is
+						 *          numerically equal to this {Double}; a value
+						 *          less than {0} if this {Double}
+						 *          is numerically less than {anotherDouble};
+						 *          and a value greater than {0} if this
+						 *          {Double} is numerically greater than
+						 *          {anotherDouble}.
+						 */
+						int compareTo(Double anotherDouble);
+						
+						/**
+						 * Returns a representation of the specified floating-point value
+						 * according to the IEEE 754 floating-point "double
+						 * format" bit layout.
+						 *
+						 * @param   value   a double precision floating-point number.
+						 * @return the bits that represent the floating-point number.
+						 */
+						static long doubleToLongBits(double valueDouble);
+						
+						/**
+						 * Returns a representation of the specified floating-point value
+						 * according to the IEEE 754 floating-point "double
+						 * format" bit layout, preserving Not-a-Number (NaN) values.
+						 *
+						 * @param   value   a double precision floating-point number.
+						 * @return the bits that represent the floating-point number.
+						 */
+						static long doubleToRawLongBits(double doubleInput);
+						
+						/**
+						 * Compares this object against the specified object.
+						 *
+						 * @param   obj   the object to compare with.
+						 * @return  {true} if the objects are the same;
+						 *          {false} otherwise.
+						 * @see java.lang.Double#doubleToLongBits(double)
+						 */
+						boolean equals(const Double &object) const;
+						
+						/**
+						 * Returns a hash code for this {Double} object.
+						 *
+						 * @return  a {hash code} value for this object.
+						 */
+						long hashCode();
+						
+						/**
+						 * Returns a hash code for a double value; compatible with
+						 * {Double.hashCode()}.
+						 *
+						 * @param value the value to hash
+						 * @return a hash code value for a double value.
+						 */
+						static long hashCode(double doubleInput);
+						
+						/**
+						 * Returns {true} if the argument is a finite floating-point
+						 * value; returns {false} otherwise (for NaN and infinity
+						 * arguments).
+						 *
+						 * @param d the double value to be tested
+						 * @return {true} if the argument is a finite
+						 * floating-point value, {false} otherwise.
+						 */
+						static boolean isFinite(double d);
+						
+						/**
+						 * Returns {true} if the specified number is infinitely
+						 * large in magnitude, {false} otherwise.
+						 *
+						 * @param   v   the value to be tested.
+						 * @return  {true} if the value of the argument is positive
+						 *          infinity or negative infinity; {false} otherwise.
+						 */
+						static boolean isInfinite(double v);
+						
+						/**
+						* Returns {true} if this {Double} value is
+						* infinitely large in magnitude, {false} otherwise.
+						*
+						* @return  {true} if the value represented by this object is
+						*          positive infinity or negative infinity;
+						*          {false} otherwise.
+						*/
+						boolean isInfinite();
+						
+						/**
+						 * Returns {true} if the specified number is a
+						 * Not-a-Number (NaN) value, {false} otherwise.
+						 *
+						 * @param   v   the value to be tested.
+						 * @return  {true} if the value of the argument is NaN;
+						 *          {false} otherwise.
+						 */
+						static boolean isNaN(double v);
+						
+						/**
+						 * Returns {true} if this {Double} value is
+						 * a Not-a-Number (NaN), {false} otherwise.
+						 *
+						 * @return  {true} if the value represented by this object is
+						 *          NaN; {false} otherwise.
+						 */
+						boolean isNaN();
+						
+						/**
+						 * Returns the double value corresponding to a given
+						 * bit representation.
+						 *
+						 * @param   bits   any {long} integer.
+						 * @return  the double floating-point value with the same
+						 *          bit pattern.
+						 */
+						static double longBitsToDouble(long bits);
+						
+						/**
+						 * Returns the smaller of two double values
+						 * as if by calling {@link Math#min(double, double) Math.min}.
+						 *
+						 * @param a the first operand
+						 * @param b the second operand
+						 * @return the smaller of {a} and {b}.
+						 * @see java.util.function.BinaryOperator
+						 */
+						static double min(double a, double b);
+						
+						// TODO(thoangminh): Implement later
 //            /**
 //             * Returns a hexadecimal string representation of the
 //             * double argument. All characters mentioned below
@@ -492,59 +492,75 @@ namespace Java {
 //             * @return a hex string representation of the argument.
 //             */
 //            static String toHexString(double d);
-
-            /**
-            * Convert from string to double
-            *
-            * @param      s   the string to be parsed.
-            * @return     a {Double} object holding the value
-            *             represented by the {String} argument.
-            */
-            static Double valueOf(String stringInput);
-
-            /**
-            * Assign value to Double variable
-            *
-            * @param  d a double value.
-            * @return a {Double} instance representing {d}.
-            */
-            static Double valueOf(double doubleInput);
-
-        private:
-            double original;
-            string originalString;
-
-            /**
-            * Convert double to binary 64 bit
-            * (Double-precision floating-point format
-            * In IEEE 754-2008)
-            *
-            * @param double
-            * @return string binary 64 bit of input
-            */
-            static String doubleToBinary64StringType(double doubleInput);
-
-            /**
-            * Convert binary64StringType To Double
-            * (Double-precision floating-point format
-            * In IEEE 754-2008)
-            * To Double
-             *
-            * @param  string
-            * @return double
-            */
-            static double binary64StringTypeToDouble(String Binary64StringTypeInput);
-
-            /**
-            * Convert longBits To Binary64StringType
-            * (Double-precision floating-point format
-            * In IEEE 754-2008)
-             *
-            * @param  long
-            * @return string
-            */
-            static String longBitsToBinary64StringType(long longBitsInput);
-        };
-    }  // namespace Lang
+						
+						/**
+						* Convert from string to double
+						*
+						* @param      s   the string to be parsed.
+						* @return     a {Double} object holding the value
+						*             represented by the {String} argument.
+						*/
+						static Double valueOf(String stringInput);
+						
+						/**
+						* Assign value to Double variable
+						*
+						* @param  d a double value.
+						* @return a {Double} instance representing {d}.
+						*/
+						static Double valueOf(double doubleInput);
+				
+				private:
+						double original;
+						string originalString;
+						
+						/**
+						* Convert double to binary 64 bit
+						* (Double-precision floating-point format
+						* In IEEE 754-2008)
+						*
+						* @param double
+						* @return string binary 64 bit of input
+						*/
+						static String doubleToBinary64StringType(double doubleInput);
+						
+						/**
+						* Convert binary64StringType To Double
+						* (Double-precision floating-point format
+						* In IEEE 754-2008)
+						* To Double
+						 *
+						* @param  string
+						* @return double
+						*/
+						static double binary64StringTypeToDouble(String Binary64StringTypeInput);
+						
+						/**
+						* Convert longBits To Binary64StringType
+						* (Double-precision floating-point format
+						* In IEEE 754-2008)
+						 *
+						* @param  long
+						* @return string
+						*/
+						static String longBitsToBinary64StringType(long longBitsInput);
+				
+				public:
+						inline size_t operator()(const Double &target) const {
+							String targetLong = target.toString();
+							return std::_Hash_impl::hash(targetLong.toString(), targetLong.length());
+						}
+				};
+		}  // namespace Lang
 }  // namespace Java
+
+namespace std {
+		template <>
+		struct hash<Double> {
+				std::size_t operator()(const Double &k) const {
+					return Double()(k);
+				}
+		};
+}
+
 #endif  // JAVA_LANG_DOUBLE_DOUBLE_HPP

--- a/java/lang/Float/Float.hpp
+++ b/java/lang/Float/Float.hpp
@@ -35,475 +35,475 @@
 #include "../Comparable/Comparable.hpp"
 
 namespace Java {
-	namespace Lang {
-
-		class Float :
-				virtual public Number,
-				virtual public Comparable<Float> {
-		private:
-			float original;
-			string originalString;
-
-		public:
-			/**
-             * A constant holding the positive infinity of type float.
-             */
-			static constexpr float POSITIVE_INFINITY = INFINITY;
-
-			/**
-             * A constant holding the negative infinity of type float.
-             */
-			static constexpr float NEGATIVE_INFINITY = -INFINITY;
-
-			/**
-             * A constant holding a Not-a-Number NaN value of type float.
-             */
-			static constexpr float NaN = NAN;
-
-			/**
-             * A constant holding the largest positive finite value of type
-             */
-			static constexpr float MAX_VALUE = std::numeric_limits<float>::max();  // 3.40282e+38
-
-			/**
-             * The smallest subnormal value has sign bit = 0, exponent = 0
-             * and only the least significant bit of the fraction is 1
-             */
-			static constexpr float MIN_NORMAL = 1.4013e-45f;
-
-			/**
-             * A constant holding the smallest value of type
-             */
-			static constexpr float MIN_VALUE = std::numeric_limits<float>::min();  // 1.17549e-38
-
-			/**
-             * Minimum exponent a normalized float number may have
-             */
-			static constexpr int  MIN_EXPONENT = -126;
-
-			/**
-             * Maximum exponent a finite float variable may have.
-             */
-			static constexpr int MAX_EXPONENT = 127;
-
-			/**
-             * The number of bits used to represent a float value.
-             *
-             */
-			static constexpr int SIZE = 32;
-
-			/**
-             * The number of bytes used to represent a float value.
-             */
-			static constexpr int BYTES = SIZE / Bytes::SIZE;
-
-			/**
-             * The number of logical bits in the significand of a float number,
-             * including the implicit bit.
-             */
-			static constexpr int SIGNIFICAND_WIDTH = 24;
-
-			/**
-             * The exponent the smallest positive float subnormal value would have
-             * if it could be normalized.
-             */
-			static constexpr int MIN_SUB_EXPONENT = MIN_EXPONENT - (SIGNIFICAND_WIDTH - 1);
-
-			/**
-             * Bias used in representing a float exponent.
-             */
-			static const int EXP_BIAS = 127;
-
-			/**
-             * Bit mask to isolate the sign bit of a float.
-             */
-			static const int SIGN_BIT_MASK = 0x80000000;
-
-			/**
-             * Bit mask to isolate the exponent field of a float.
-             */
-			static const int EXP_BIT_MASK = 0x7F800000;
-
-			/**
-             * Bit mask to isolate the significand field of a float.
-             */
-			static const int SIGNIF_BIT_MASK = 0x007FFFFF;
-
-		public:
-			/**
-             * Float initialization
-             */
-			Float();
-
-			/**
-             * Float initialization
-             *
-             * @param original - float value
-             */
-			Float(float original);
-
-			/**
-             * Float initialization
-             *
-             * @param target - Float
-             */
-			Float(const Float &target);
-
-			/**
-			 * Float initialization
-			 *
-			 * @param inputString - String
-			 */
-			Float(String inputString);
-
-			/**
-             * Float destructor
-             */
-			~Float();
-
-		public:
-			/**
-             * Adds two operands
-             *
-             * @return Float
-             */
-			Float operator+(const Float &target);
-
-			/**
-             * Subtracts second operand from the first
-             *
-             * @return Float
-             */
-			Float operator-(const Float &target);
-
-			/**
-             *  Multiplies both operands
-             *
-             * @return Float
-             */
-			Float operator*(const Float &target);
-
-			/**
-             * Divides numerator by de-numerator
-             *
-             * @return Float
-             */
-			Float operator/(const Float &target);
-
-			/**
-             * Checks if the values of two operands
-             * are equal or not,
-             *
-             * @return boolean
-             */
-			boolean operator==(const Float &target) const;
-
-			/**
-             * Checks if the values of two operands
-             * are equal or not
-             *
-             * @return boolean
-             */
-			boolean operator!=(const Float &target) const;
-
-			/**
-             * Checks if the value of left operand
-             * is greater than the value of right operand
-             *
-             * @return boolean
-             */
-			boolean operator>(const Float &target) const;
-
-			/**
-             * Checks if the value of left operand
-             * is less than the value of right operand
-             *
-             * @return boolean
-             */
-			boolean operator<(const Float &target) const;
-
-			/**
-             * Checks if the value of left operand
-             * is greater than or equal to the value of right operand
-             *
-             * @return boolean
-             */
-			boolean operator>=(const Float &target) const;
-
-			/**
-             *  Checks if the value of left operand
-             *  is less than or equal to the value of right operand
-             *
-             * @return boolean
-             */
-			boolean operator<=(const Float &target) const;
-
-			/**
-             *  Called Logical AND operator.
-             *  If both the operands are non-zero
-             *
-             * @return boolean
-             */
-			boolean operator&&(const Float &target) const;
-
-			/**
-             *  Called Logical OR Operator.
-             *  If any of the two operands is non-zero
-             *
-             * @return boolean
-             */
-			boolean operator||(const Float &target) const;
-
-
-			/**
-             * Simple assignment operator,
-             * Assigns values from right side operands
-             * to left side operand
-             *
-             * @param   target
-             * @return  Float
-             */
-			Float& operator=(const Float &target);
-
-			/**
-             * Add AND assignment operator,
-             * It adds right operand to the left operand
-             * and assign the result to left operand
-             *
-             * @param   target
-             * @return  Float
-             */
-			Float operator+=(const Float &target) const;
-
-			/**
-             * Subtract AND assignment operator,
-             * It subtracts right operand from the left operand
-             * and assign the result to left operand
-             *
-             * @param   target
-             * @return  Float
-             */
-			Float operator-=(const Float &target) const;
-
-			/**
-             * Multiply AND assignment operator,
-             * It multiplies right operand with the left operand
-             * and assign the result to left operand
-             *
-             * @param   target
-             * @return  Float
-             */
-			Float operator*=(const Float &target) const;
-
-			/**
-             * Divide AND assignment operator,
-             * It divides left operand with the right operand
-             * and assign the result to left operand
-             *
-             * @param   target
-             * @return  Float
-             */
-			Float operator/=(const Float &target) const;
-
-			/**
-             * Short value of Float
-             *
-             * @return short
-             */
-			short shortValue() const override;
-
-			/**
-             * Float value in Float
-             *
-             * @return int
-             */
-			int intValue() const override;
-
-			/**
-             * Float value in Long
-             *
-             * @return long
-             */
-			long longValue() const override;
-
-			/**
-             * Float value in float
-             *
-             * @return float
-             */
-			float floatValue() const override;
-
-			/**
-             * Float value in double
-             *
-             * @return double
-             */
-			double doubleValue() const override;
-
-			/**
-             * Float to String
-             *
-             * @return String
-             */
-			string toString() const override;
-
-			/**
-             * Returns a string representation of the float
-             * argument. All characters mentioned below are ASCII characters.
-             *
-             * @param   inputFloat   the float to be converted.
-             * @return  a string representation of the argument.
-             */
-			static String toString(float inputFloat);
-
-			/**
-             * String to Float
-             *
-             * @param  inputString
-             * @return Float
-             */
-			static Float parseFloat(String inputString);
-
-			/**
-             * Returns the value of this Float as a byte
-             * after a narrowing primitive conversion.
-             *
-             * @return  the float value represented by this object
-             *          converted to type byte
-             */
-			byte byteValue() const ;
-
-			/**
-             * Compares the two specified float values. The sign
-             * of the integer value returned is the same as that of the
-             * integer that would be returned by the call:
-             * Float(float1).compareTo(Float(d2))
-             *
-             * @param   float1   - the first float to compare
-             * @param   float2   - the second float to compare
-             * @return  the value 0 if float1 is
-             *          numerically equal to float2; a value less than
-             *          0 if float1 is numerically less than
-             *          float2; and a value greater than 0
-             *          if float1 is numerically greater than
-             *          float2.
-             */
-			static int compare(float float1, float float2);
-
-			/**
-             * Compares two Float objects numerically.
-             *
-             * @param   anotherFloat   the Float to be compared.
-             * @return  the value 0 if anotherFloat is
-             *          numerically equal to this Float; a value
-             *          less than 0 if this Float
-             *          is numerically less than anotherFloat;
-             *          and a value greater than 0 if this
-             *          Float is numerically greater than
-             *          anotherFloat.
-             */
-			int compareTo(const Float &anotherFloat) const override;
-
-			/**
-             * Compares this object against the specified object.
-             *
-             * @param   obj   the object to compare with.
-             * @return  true if the objects are the same;
-             *          false otherwise.
-             * @see java.lang.Float#floatToLongBits(float)
-             */
-			boolean equals(const Float &object) const;
-
-			/**
-             * Returns a hash code for this Float object.
-             *
-             * @return  a hash code value for this object.
-             */
-			int hashCode();
-
-			/**
-             * Returns a hash code for a float value; compatible with
-             * Float.hashCode().
-             *
-             * @param value the value to hash
-             * @return a hash code value for a float value.
-             */
-			static int hashCode(float floatInput);
-
-			/**
-             * Returns true if the argument is a finite floating-point
-             * value; returns false otherwise (for NaN and infinity
-             * arguments).
-             *
-             * @param   inputFloat the float value to be tested
-             * @return  true    if the argument is a finite
-             *                  floating-point value,
-             *          false   otherwise.
-             */
-			static boolean isFinite(float inputFloat);
-
-			/**
-             * Returns true if the specified number is infinitely
-             * large in magnitude, false otherwise.
-             *
-             * @param   valueFloat   the value to be tested.
-             * @return  true    - if the value of the argument is positive
-             *                    infinity or negative infinity;
-             *          false   - otherwise.
-             */
-			static boolean isInfinite(float valueFloat);
-
-			/**
-             * Returns true if this Float value is
-             * infinitely large in magnitude, false otherwise.
-             *
-             * @return  true     - if the value represented by this object is
-             *                     positive infinity or negative infinity;
-             *          false    - otherwise.
-             */
-			boolean isInfinite();
-
-			/**
-             * Returns true if the specified number is a
-             * Not-a-Number NaN value, false otherwise.
-             *
-             * @param   valueFloat  - the value to be tested.
-             * @return  true        - if the value of the argument is NaN;
-             *          false       - otherwise.
-             */
-			static boolean isNaN(float valueFloat);
-
-			/**
-             * Returns true if this Float value is
-             * a Not-a-Number NaN, false otherwise.
-             *
-             * @return  true    - if the value represented by this
-             *                    object is NaN;
-             *          false   - otherwise.
-             */
-			boolean isNaN() ;
-
-			/**
-             * Returns the float value corresponding to a given
-             * bit representation.
-             *
-             * @param   bits  - any int integer.
-             * @return  the float floating-point value with the same
-             *          bit pattern.
-             */
-			static float intBitsToFloat(int intBitsInput);
-
-			/**
-             * Returns the smaller of two float values
-             * as if by calling Math#min(float, float) Math.min.
-             *
-             * @param numberFloat the first operand
-             * @param anotherNumberFloat the second operand
-             * @return the smaller of a and b.
-             */
-			static float min(float numberFloat, float anotherNumberFloat);
-
-			// TODO(thoangminh): Implement this method later
+		namespace Lang {
+				
+				class Float :
+					virtual public Number,
+					virtual public Comparable<Float> {
+				private:
+						float original;
+						string originalString;
+				
+				public:
+						/**
+						 * A constant holding the positive infinity of type float.
+						 */
+						static constexpr float POSITIVE_INFINITY = INFINITY;
+						
+						/**
+						 * A constant holding the negative infinity of type float.
+						 */
+						static constexpr float NEGATIVE_INFINITY = -INFINITY;
+						
+						/**
+						 * A constant holding a Not-a-Number NaN value of type float.
+						 */
+						static constexpr float NaN = NAN;
+						
+						/**
+						 * A constant holding the largest positive finite value of type
+						 */
+						static constexpr float MAX_VALUE = std::numeric_limits<float>::max();  // 3.40282e+38
+						
+						/**
+						 * The smallest subnormal value has sign bit = 0, exponent = 0
+						 * and only the least significant bit of the fraction is 1
+						 */
+						static constexpr float MIN_NORMAL = 1.4013e-45f;
+						
+						/**
+						 * A constant holding the smallest value of type
+						 */
+						static constexpr float MIN_VALUE = std::numeric_limits<float>::min();  // 1.17549e-38
+						
+						/**
+						 * Minimum exponent a normalized float number may have
+						 */
+						static constexpr int MIN_EXPONENT = -126;
+						
+						/**
+						 * Maximum exponent a finite float variable may have.
+						 */
+						static constexpr int MAX_EXPONENT = 127;
+						
+						/**
+						 * The number of bits used to represent a float value.
+						 *
+						 */
+						static constexpr int SIZE = 32;
+						
+						/**
+						 * The number of bytes used to represent a float value.
+						 */
+						static constexpr int BYTES = SIZE / Byte::SIZE;
+						
+						/**
+						 * The number of logical bits in the significand of a float number,
+						 * including the implicit bit.
+						 */
+						static constexpr int SIGNIFICAND_WIDTH = 24;
+						
+						/**
+						 * The exponent the smallest positive float subnormal value would have
+						 * if it could be normalized.
+						 */
+						static constexpr int MIN_SUB_EXPONENT = MIN_EXPONENT - ( SIGNIFICAND_WIDTH - 1 );
+						
+						/**
+						 * Bias used in representing a float exponent.
+						 */
+						static const int EXP_BIAS = 127;
+						
+						/**
+						 * Bit mask to isolate the sign bit of a float.
+						 */
+						static const int SIGN_BIT_MASK = 0x80000000;
+						
+						/**
+						 * Bit mask to isolate the exponent field of a float.
+						 */
+						static const int EXP_BIT_MASK = 0x7F800000;
+						
+						/**
+						 * Bit mask to isolate the significand field of a float.
+						 */
+						static const int SIGNIF_BIT_MASK = 0x007FFFFF;
+				
+				public:
+						/**
+						 * Float initialization
+						 */
+						Float();
+						
+						/**
+						 * Float initialization
+						 *
+						 * @param original - float value
+						 */
+						Float(float original);
+						
+						/**
+						 * Float initialization
+						 *
+						 * @param target - Float
+						 */
+						Float(const Float &target);
+						
+						/**
+						 * Float initialization
+						 *
+						 * @param inputString - String
+						 */
+						Float(String inputString);
+						
+						/**
+						 * Float destructor
+						 */
+						~Float();
+				
+				public:
+						/**
+						 * Adds two operands
+						 *
+						 * @return Float
+						 */
+						Float operator+(const Float &target);
+						
+						/**
+						 * Subtracts second operand from the first
+						 *
+						 * @return Float
+						 */
+						Float operator-(const Float &target);
+						
+						/**
+						 *  Multiplies both operands
+						 *
+						 * @return Float
+						 */
+						Float operator*(const Float &target);
+						
+						/**
+						 * Divides numerator by de-numerator
+						 *
+						 * @return Float
+						 */
+						Float operator/(const Float &target);
+						
+						/**
+						 * Checks if the values of two operands
+						 * are equal or not,
+						 *
+						 * @return boolean
+						 */
+						boolean operator==(const Float &target) const;
+						
+						/**
+						 * Checks if the values of two operands
+						 * are equal or not
+						 *
+						 * @return boolean
+						 */
+						boolean operator!=(const Float &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is greater than the value of right operand
+						 *
+						 * @return boolean
+						 */
+						boolean operator>(const Float &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is less than the value of right operand
+						 *
+						 * @return boolean
+						 */
+						boolean operator<(const Float &target) const;
+						
+						/**
+						 * Checks if the value of left operand
+						 * is greater than or equal to the value of right operand
+						 *
+						 * @return boolean
+						 */
+						boolean operator>=(const Float &target) const;
+						
+						/**
+						 *  Checks if the value of left operand
+						 *  is less than or equal to the value of right operand
+						 *
+						 * @return boolean
+						 */
+						boolean operator<=(const Float &target) const;
+						
+						/**
+						 *  Called Logical AND operator.
+						 *  If both the operands are non-zero
+						 *
+						 * @return boolean
+						 */
+						boolean operator&&(const Float &target) const;
+						
+						/**
+						 *  Called Logical OR Operator.
+						 *  If any of the two operands is non-zero
+						 *
+						 * @return boolean
+						 */
+						boolean operator||(const Float &target) const;
+						
+						
+						/**
+						 * Simple assignment operator,
+						 * Assigns values from right side operands
+						 * to left side operand
+						 *
+						 * @param   target
+						 * @return  Float
+						 */
+						Float &operator=(const Float &target);
+						
+						/**
+						 * Add AND assignment operator,
+						 * It adds right operand to the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param   target
+						 * @return  Float
+						 */
+						Float operator+=(const Float &target) const;
+						
+						/**
+						 * Subtract AND assignment operator,
+						 * It subtracts right operand from the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param   target
+						 * @return  Float
+						 */
+						Float operator-=(const Float &target) const;
+						
+						/**
+						 * Multiply AND assignment operator,
+						 * It multiplies right operand with the left operand
+						 * and assign the result to left operand
+						 *
+						 * @param   target
+						 * @return  Float
+						 */
+						Float operator*=(const Float &target) const;
+						
+						/**
+						 * Divide AND assignment operator,
+						 * It divides left operand with the right operand
+						 * and assign the result to left operand
+						 *
+						 * @param   target
+						 * @return  Float
+						 */
+						Float operator/=(const Float &target) const;
+						
+						/**
+						 * Short value of Float
+						 *
+						 * @return short
+						 */
+						short shortValue() const override;
+						
+						/**
+						 * Float value in Float
+						 *
+						 * @return int
+						 */
+						int intValue() const override;
+						
+						/**
+						 * Float value in Long
+						 *
+						 * @return long
+						 */
+						long longValue() const override;
+						
+						/**
+						 * Float value in float
+						 *
+						 * @return float
+						 */
+						float floatValue() const override;
+						
+						/**
+						 * Float value in double
+						 *
+						 * @return double
+						 */
+						double doubleValue() const override;
+						
+						/**
+						 * Float to String
+						 *
+						 * @return String
+						 */
+						string toString() const override;
+						
+						/**
+						 * Returns a string representation of the float
+						 * argument. All characters mentioned below are ASCII characters.
+						 *
+						 * @param   inputFloat   the float to be converted.
+						 * @return  a string representation of the argument.
+						 */
+						static String toString(float inputFloat);
+						
+						/**
+						 * String to Float
+						 *
+						 * @param  inputString
+						 * @return Float
+						 */
+						static Float parseFloat(String inputString);
+						
+						/**
+						 * Returns the value of this Float as a byte
+						 * after a narrowing primitive conversion.
+						 *
+						 * @return  the float value represented by this object
+						 *          converted to type byte
+						 */
+						byte byteValue() const;
+						
+						/**
+						 * Compares the two specified float values. The sign
+						 * of the integer value returned is the same as that of the
+						 * integer that would be returned by the call:
+						 * Float(float1).compareTo(Float(d2))
+						 *
+						 * @param   float1   - the first float to compare
+						 * @param   float2   - the second float to compare
+						 * @return  the value 0 if float1 is
+						 *          numerically equal to float2; a value less than
+						 *          0 if float1 is numerically less than
+						 *          float2; and a value greater than 0
+						 *          if float1 is numerically greater than
+						 *          float2.
+						 */
+						static int compare(float float1, float float2);
+						
+						/**
+						 * Compares two Float objects numerically.
+						 *
+						 * @param   anotherFloat   the Float to be compared.
+						 * @return  the value 0 if anotherFloat is
+						 *          numerically equal to this Float; a value
+						 *          less than 0 if this Float
+						 *          is numerically less than anotherFloat;
+						 *          and a value greater than 0 if this
+						 *          Float is numerically greater than
+						 *          anotherFloat.
+						 */
+						int compareTo(const Float &anotherFloat) const override;
+						
+						/**
+						 * Compares this object against the specified object.
+						 *
+						 * @param   obj   the object to compare with.
+						 * @return  true if the objects are the same;
+						 *          false otherwise.
+						 * @see java.lang.Float#floatToLongBits(float)
+						 */
+						boolean equals(const Float &object) const;
+						
+						/**
+						 * Returns a hash code for this Float object.
+						 *
+						 * @return  a hash code value for this object.
+						 */
+						int hashCode();
+						
+						/**
+						 * Returns a hash code for a float value; compatible with
+						 * Float.hashCode().
+						 *
+						 * @param value the value to hash
+						 * @return a hash code value for a float value.
+						 */
+						static int hashCode(float floatInput);
+						
+						/**
+						 * Returns true if the argument is a finite floating-point
+						 * value; returns false otherwise (for NaN and infinity
+						 * arguments).
+						 *
+						 * @param   inputFloat the float value to be tested
+						 * @return  true    if the argument is a finite
+						 *                  floating-point value,
+						 *          false   otherwise.
+						 */
+						static boolean isFinite(float inputFloat);
+						
+						/**
+						 * Returns true if the specified number is infinitely
+						 * large in magnitude, false otherwise.
+						 *
+						 * @param   valueFloat   the value to be tested.
+						 * @return  true    - if the value of the argument is positive
+						 *                    infinity or negative infinity;
+						 *          false   - otherwise.
+						 */
+						static boolean isInfinite(float valueFloat);
+						
+						/**
+						 * Returns true if this Float value is
+						 * infinitely large in magnitude, false otherwise.
+						 *
+						 * @return  true     - if the value represented by this object is
+						 *                     positive infinity or negative infinity;
+						 *          false    - otherwise.
+						 */
+						boolean isInfinite();
+						
+						/**
+						 * Returns true if the specified number is a
+						 * Not-a-Number NaN value, false otherwise.
+						 *
+						 * @param   valueFloat  - the value to be tested.
+						 * @return  true        - if the value of the argument is NaN;
+						 *          false       - otherwise.
+						 */
+						static boolean isNaN(float valueFloat);
+						
+						/**
+						 * Returns true if this Float value is
+						 * a Not-a-Number NaN, false otherwise.
+						 *
+						 * @return  true    - if the value represented by this
+						 *                    object is NaN;
+						 *          false   - otherwise.
+						 */
+						boolean isNaN();
+						
+						/**
+						 * Returns the float value corresponding to a given
+						 * bit representation.
+						 *
+						 * @param   bits  - any int integer.
+						 * @return  the float floating-point value with the same
+						 *          bit pattern.
+						 */
+						static float intBitsToFloat(int intBitsInput);
+						
+						/**
+						 * Returns the smaller of two float values
+						 * as if by calling Math#min(float, float) Math.min.
+						 *
+						 * @param numberFloat the first operand
+						 * @param anotherNumberFloat the second operand
+						 * @return the smaller of a and b.
+						 */
+						static float min(float numberFloat, float anotherNumberFloat);
+						
+						// TODO(thoangminh): Implement this method later
 //            /**
 //             * Returns a hexadecimal string representation of the
 //             * float argument. All characters mentioned below
@@ -513,80 +513,95 @@ namespace Java {
 //             * @return a hex string representation of the argument.
 //             */
 //            static String toHexString(float inputFloat);
-
-			/**
-             * Convert from string to float
-             *
-             * @param      stringInput   - the string to be parsed.
-             * @return     a Float object holding the value
-             *             represented by the {String} argument.
-             * @throws     NumberFormatException  if the string does not contain a
-             *             parsable number.
-             */
-			static Float valueOf(String stringInput);
-
-			/**
-             * Assign value to Float variable
-             *
-             * @param  inputFloat    - float value.
-             * @return a Float instance representing inputFloat.
-             */
-			static Float valueOf(float inputFloat);
-
-			/**
-             * Returns a representation of the specified floating-point value
-             * according to the IEEE 754 floating-point "float
-             * format" bit layout, preserving Not-a-Number NaN values.
-             *
-             * @param   floatInput  - float precision floating-point number.
-             * @return  int         - the bits that represent the floating-point number.
-             */
-			static int floatToRawIntBits(float floatInput);
-
-			/**
-             * Returns a representation of the specified floating-point value
-             * according to the IEEE 754 floating-point "float
-             * format" bit layout, preserving Not-a-Number NaN values.
-             *
-             * @param   floatInput  - value   a float precision floating-point number.
-             * @return  int         - the bits that represent the floating-point number.
-             */
-			static int floatToIntBits(float inputFloat);
-
-		private:
-			/**
-             * Convert float to binary 32 bit
-             * (Single-precision floating-point format
-             * In IEEE 754-2008)
-             *
-             * @param    floatInput
-             * @return   String binary 32 bit of input
-             */
-			static String floatToBinary32StringType(float floatInput);
-
-			/**
-             * Convert binary32StringType To Float
-             * (Float-precision floating-point format
-             * In IEEE 754-2008)
-             * To Float
-             *
-             * @param  binary32StringTypeInput
-             * @return float
-             */
-			static float binary32StringTypeToFloat(
-					String binary32StringTypeInput);
-
-			/**
-             * Convert intBits To Binary64StringType
-             * (Float-precision floating-point format
-             * In IEEE 754-2008)
-             *
-             * @param  intBitsInput
-             * @return string
-             */
-			static String intBitsToBinary32StringType(int intBitsInput);
-		};
-	}  // namespace Lang
+						
+						/**
+						 * Convert from string to float
+						 *
+						 * @param      stringInput   - the string to be parsed.
+						 * @return     a Float object holding the value
+						 *             represented by the {String} argument.
+						 * @throws     NumberFormatException  if the string does not contain a
+						 *             parsable number.
+						 */
+						static Float valueOf(String stringInput);
+						
+						/**
+						 * Assign value to Float variable
+						 *
+						 * @param  inputFloat    - float value.
+						 * @return a Float instance representing inputFloat.
+						 */
+						static Float valueOf(float inputFloat);
+						
+						/**
+						 * Returns a representation of the specified floating-point value
+						 * according to the IEEE 754 floating-point "float
+						 * format" bit layout, preserving Not-a-Number NaN values.
+						 *
+						 * @param   floatInput  - float precision floating-point number.
+						 * @return  int         - the bits that represent the floating-point number.
+						 */
+						static int floatToRawIntBits(float floatInput);
+						
+						/**
+						 * Returns a representation of the specified floating-point value
+						 * according to the IEEE 754 floating-point "float
+						 * format" bit layout, preserving Not-a-Number NaN values.
+						 *
+						 * @param   floatInput  - value   a float precision floating-point number.
+						 * @return  int         - the bits that represent the floating-point number.
+						 */
+						static int floatToIntBits(float inputFloat);
+				
+				private:
+						/**
+						 * Convert float to binary 32 bit
+						 * (Single-precision floating-point format
+						 * In IEEE 754-2008)
+						 *
+						 * @param    floatInput
+						 * @return   String binary 32 bit of input
+						 */
+						static String floatToBinary32StringType(float floatInput);
+						
+						/**
+						 * Convert binary32StringType To Float
+						 * (Float-precision floating-point format
+						 * In IEEE 754-2008)
+						 * To Float
+						 *
+						 * @param  binary32StringTypeInput
+						 * @return float
+						 */
+						static float binary32StringTypeToFloat(
+							String binary32StringTypeInput);
+						
+						/**
+						 * Convert intBits To Binary64StringType
+						 * (Float-precision floating-point format
+						 * In IEEE 754-2008)
+						 *
+						 * @param  intBitsInput
+						 * @return string
+						 */
+						static String intBitsToBinary32StringType(int intBitsInput);
+				
+				public:
+						inline size_t operator()(const Float &target) const {
+							String targetString = target.toString();
+							return std::_Hash_impl::hash(targetString.toString(), targetString.length());
+						}
+				};
+		}  // namespace Lang
 }  // namespace Java
+
+namespace std {
+		template <>
+		struct hash<Float> {
+				std::size_t operator()(const Float &k) const {
+					return Float()(k);
+				}
+		};
+}
 
 #endif  // JAVA_LANG_FLOAT_FLOAT_HPP

--- a/java/lang/Integer/Integer.hpp
+++ b/java/lang/Integer/Integer.hpp
@@ -37,708 +37,721 @@
 using namespace Java::Lang;
 
 namespace Java {
-	namespace Lang {
-		class Integer;
-		
-		class Integer : public Number , public virtual Comparable<Integer> {
-        private:
-			int original;
- 			string originalString;
-
-        private:
-            /**
-             * Max value of unsigned int
-             */
-            static constexpr unsigned int UNSIGNED_INT_MAX = 0xffffffff;
-
-            /**
-             * Max value of unsigned int
-             */
-            static constexpr unsigned int UNSIGNED_INT_MIN = 0;
-
-        public:
-            /**
-             * The number of bits used to represent an int value in two's complement binary form.
-             */
-            static const int SIZE = 32;
-
-            /**
-             * The number of bytes used to represent a int value in two's complement binary form.
-             */
-            // TODO change from 8 to Byte::SIZE
-            static const int BYTES = SIZE / 8;
-
-            /**
-             * A constant holding the maximum value of type int
-             */
-            static constexpr int MAX_VALUE = std::numeric_limits<int>::max();  // 2,147,483,647   2147483647
-
-            /**
-             * A constant holding the minimum value of type int
-             */
-            static constexpr int MIN_VALUE = std::numeric_limits<int>::min();  // –2,147,483,648  –2147483648
-
-        public:
-            /**
-             * Integer initialization
-             *
-             */
-            Integer();
-
-            /**
-             * Integer initialization with specific original value
-             *
-             * @param original
-             */
-            Integer(int original);
-
-            /**
-             * Integer initialization with specific original value from String
-             *
-             * @param inputString
-             */
-            Integer(String inputString);
-
-            /**
-             * Copy Constructor
-             *
-             * @param Integer &target
-             */
-            Integer(const Integer &target);
-
-            /**
-             * Integer Destructor
-             */
-            ~Integer();
-
-        public:
-            /**
-             * Integer to Char
-             *
-             * @return char
-             */
-            char charValue() const;
-
-            /**
-             * Integer to string
-             *
-             * @return string
-             */
-            string stringValue() const;
-
-            /**
-             * Returns a String object representing
-             * the specified integer.
-             *
-             * @return string
-             */
-            string toString() const override;
-
-            /**
-             * Assign value of this object same as target value
-             *
-             * @param target
-             * @return Integer
-             */
-            Integer &operator=(const Integer &target);
-
-            /**
-             * Compares two Integer objects numerically.
-             *
-             * @param  Integer anotherInteger
-             * @return the value 0 if this Integer is equal to the argument Integer;
-             * a value less than 0 if this Integer is numerically less than the argument Integer;
-             * and a value greater than 0 if this Integer is numerically greater than
-             * the argument Integer (signed comparison).
-             */
-            int compareTo(const Integer &anotherInteger) const override ;
-
-            /**
-             * Make a summation with target Integer
-             *
-             * @return Integer
-             */
-            Integer operator+(const Integer &target);
-
-            /**
-             * Make a subtraction with target Integer
-             *
-             * @return Integer
-             */
-            Integer operator-(const Integer &target);
-
-            /**
-             * Make a division from this Integer with target
-             *
-             * @throw ArithmeticException if target is zero
-             * @return Integer
-             */
-            Integer operator/(const Integer &target);
-
-            /**
-             * Make a multiple from this Integer with target
-             *
-             * @return Integer
-             */
-            Integer operator*(const Integer &target);
-
-            /**
-             * Make a modulo from this Integer with target
-             *
-             * @throw ArithmeticException if target is zero
-             * @return Integer
-             */
-            Integer operator%(const Integer &target);
-
-            /**
-             * Compare this Integer is equal to target
-             *
-             * @return boolean
-             */
-            boolean operator==(const Integer &target) const;
-
-            /**
-             * Compare this Integer is not equal to target
-             *
-             * @return bool
-             */
-            boolean operator!=(const Integer &target) const;
-
-            /**
-             * Compare this Integer is less than target
-             *
-             * @return bool
-             */
-            boolean operator<(const Integer &target) const;
-
-            /**
-             * Compare this Integer is more than target
-             *
-             * @return bool
-             */
-            boolean operator>(const Integer &target) const;
-
-            /**
-             * Compare this Integer is equal to or less than target
-             *
-             * @return bool
-             */
-            boolean operator<=(const Integer &target) const;
-
-            /**
-             * Compare this Integer is equal to
-             * or greater than target
-             *
-             * @return bool
-             */
-            boolean operator>=(const Integer &target) const;
-
-            /**
-             * Add target to this Integer and assign the value to this Integer
-             *
-             * @param target
-             * @return Integer
-             */
-            Integer &operator+=(const Integer &target);
-
-            /**
-             * Subtract target from this Integer and assign the value to this Integer
-             *
-             * @param target
-             * @return Integer
-             */
-            Integer &operator-=(const Integer &target);
-
-            /**
-             * Divide this Integer with target and assign the value to this Integer
-             *
-             * @throw ArithmeticException if target is zero
-             * @param target
-             * @return Integer
-             */
-            Integer &operator/=(const Integer &target);
-
-            /**
-             * Multiply this Integer with target and assign the value to this Integer
-             *
-             * @param target
-             * @return Integer
-             */
-            Integer &operator*=(const Integer &target);
-
-            /**
-             * Modulus this Integer with target and assign the value to this Integer
-             *
-             * @throw ArithmeticException if target is zero
-             * @param target
-             * @return Integer
-             */
-            Integer &operator%=(const Integer &target);
-
-            /**
-             * Returns the number of one-bits in the
-             * two's complement binary representation
-             * of the specified int value.
-             *
-             * @param inputInt
-             * @return int
-             */
-            static int bitCount(int inputInt);
-
-            /**
-             * Returns the value of this Integer as a byte
-             * after a narrowing primitive conversion.
-             *
-             * @return byte
-             */
-            byte byteValue();
-
-            /**
-             * Compares two int values numerically.
-             *
-             * @param intA
-             * @param intB
-             * @return the value 0 if intA == intB; a value less than 0 if intA < intB;
-             * and a value greater than 0 if intA > intB
-             */
-            static int compare(int intA, int intB);
-
-            /**
-             * Compares two int values numerically
-             * treating the values as unsigned.
-             *
-             * @param intA
-             * @param intA
-             * @return the value 0 if intA == intB;
-             * a value less than 0 if intA < intB as unsigned values;
-             * and a value greater than 0 if intA > intB as unsigned values
-             */
-            static int compareUnsigned(int intA, int intB);
-
-            /**
-             * Decodes a String into an Integer. Accepts decimal, hexadecimal, and octal numbers
-             *
-             * @param inputString
-             * @throw NumberFormatException - if the String does not contain a parsable integer
-             * or the String contain a number outside the range of integer
-             * @return an Integer object holding the int value represented by inputString
-             */
-            static Integer decode(String inputString);
-
-            /**
-             * Returns the unsigned quotient of dividing the first argument by the second
-             * where each argument and the result is interpreted as an unsigned value
-             *
-             * @param dividend
-             * @param divisor
-             * @return the unsigned quotient of the first argument divided by the second argument
-             */
-            static int divideUnsigned(int dividend, int divisor);
-
-            /**
-             * Returns the value of this Integer as a double after
-             * a widening primitive conversion.
-             *
-             * @return the value of this Integer as a double
-             */
-            double doubleValue() const override;
-
-            /**
-             * Compares this object to the specified object.
-             *
-             * @param object
-             * @return true if the objects are the same; false otherwise.
-             */
-            // TODO need instanceof temporary use Integer instead of Object
-            boolean equals(Integer object);
-
-            /**
-             * Returns the value of this Integer as
-             * a float after a widening primitive conversion.
-             *
-             * @return the value of this Integer as a float
-             */
-            float floatValue() const override;
-
-            /**
-             * Determines the integer value of the system property with the specified name.
-             *
-             * @param propertyName
-             * @throw SecurityException
-             * @return the Integer value of the property.
-             */
-            // Not support this method yet
-            // static Integer getInteger(String propertyName); // TODO(thoangminh): research it
-
-            /**
-             * Determines the integer value of the system property with the specified name.
-             *
-             * @param propertyName
-             * @param defaultValue
-             * @throw SecurityException
-             * @return the Integer value of the property.
-             */
-            // Not support this method yet
-            // static Integer getInteger(String propertyName, int defaultValue);
-
-            /**
-             * Returns the integer value of the system property with the specified name.
-             *
-             * @param propertyName
-             * @param defaultValue
-             * @throw SecurityException
-             * @return Returns the integer value of the system property with the specified name.
-             */
-            // Not support this method yet
-            // static Integer getInteger(String propertyName, Integer defaultValue);
-
-            /**
-             * Returns a hash code for this Integer.
-             *
-             * @return hash code of this Integer
-             * equal to the primitive int value represented by this Integer object.
-             */
-            long hashCode() const override;
-
-            /**
-             * Returns a hash code for a int value;
-             *
-             * @param inputInt
-             * @return a hash code value for inputInt
-             */
-            static int hashCode(int inputInt);
-
-            /**
-             * Returns an int value with at most a single one-bit, in the position of
-             * the highest-order ("leftmost") one-bit in the specified int value.
-             *
-             * @param inputInt
-             * @return an int value with a single one-bit,
-             * in the position of the highest-order one-bit in the specified value,
-             * or zero if the specified value is itself equal to zero.
-             */
-            static int highestOneBit(int inputInt);
-
-            /**
-             * Returns the value of this Integer as an int .
-             *
-             * @return the value of this Integer as an int
-             */
-            int intValue() const override;
-
-            /**
-             * Returns the value of this Integer as an long after
-             * a widening primitive conversion
-             *
-             * @return he value of this Integer as an long
-             */
-            long longValue() const override;
-
-            /**
-             * Returns an int value with at most a single one-bit, in the position of
-             * the lowest-order ("rightmost") one-bit in the specified int value.
-             *
-             * @param inputInt
-             * @return an int value with a single one-bit, 
-             * in the position of the lowest-order one-bit in the specified value, 
-             * or zero if the specified value is itself equal to zero
-             */
-            static int lowestOneBit(int inputInt);
-
-            /**
-             * Returns the greater of two int values
-             * as if by calling Math::max(int, int).
-             *
-             * @param intA
-             * @param intB
-             * @return intA if intA >= intB, else intB
-             */
-            static int max(int intA, int intB);
-
-            /**
-             * Returns the smaller of two int values
-             * as if by calling Math::min(int,int).
-             *
-             * @param intA
-             * @param intB
-             * @return intA if intA <= intB, else intB
-             */
-            static int min(int intA, int intB);
-
-            /**
-             * Returns the number of zero bits preceding the highest-order
-             * ("leftmost") one-bit in the two's complement
-             * binary representation of the specified inputInt.
-             *
-             * @param inputInt
-             * @return the number of zero bits preceding the highest-order ("leftmost") one-bit
-             * in the two's complement binary representation of the specified int value,
-             * or 32 if the value is equal to zero.
-             */
-            static int numberOfLeadingZeros(int inputInt);
-
-            /**
-             * Returns the number of zero bits following the lowest-order ("rightmost")
-             * one-bit in the two's complement binary representation of the specified int value.
-             *
-             * @param inputInt
-             * @return the number of zero bits preceding the highest-order ("leftmost") one-bit
-             * in the two's complement binary representation of the specified int value,
-             * or 32 if the value is equal to zero.
-             */
-            static int numberOfTrailingZeros(int inputInt);
-
-            /**
-             * Parses the string argument as
-             * a signed integer in the radix
-             * specified by the second argument.
-             *
-             * @param inputString
-             * @param radix
-             * @throw NumberFormatException if
-             * The first argument is null or is a string of length zero.
-             * The radix is either smaller than Character::MIN_RADIX or larger than Character::MAX_RADIX.
-             * Any character of the string is not a digit of the specified radix,
-             * The value represented by the string is not a value of type int.
-             * @return int
-             */
-            static int parseInt(String inputString, int radix);
-
-            /**
-             * Parses the string argument as a signed decimal integer.
-             *
-             * @param inputString
-             * @throw NumberFormatException - if the string does not contain a parsable integer.
-             * @return the integer value represented by the argument in decimal.
-             */
-            static int parseInt(String inputString);
-
-            /**
-             * Parses the string argument as
-             * a signed integer in the radix
-             * specified by the second argument.
-             *
-             * @param inputString
-             * @param radix
-             * @throw NumberFormatException if
-             * The first argument is null or is a string of length zero.
-             * The radix is either smaller than Character::MIN_RADIX or larger than Character::MAX_RADIX.
-             * Any character of the string is not a digit of the specified radix,
-             * The value represented by the string is not a value of type unsigned int.
-             * @return unsigned integer value represented by the argument in decimal
-             */
-            static int parseUnsignedInt(String inputString, int radix);
-
-            /**
-             * Parses the string argument as an unsigned decimal integer
-             *
-             * @param inputString
-             * @throw NumberFormatException - if the string does not contain a parsable unsigned integer.
-             * @return unsigned integer value represented by the argument in decimal
-             */
-            static int parseUnsignedInt(String inputString);
-
-            /**
-             * Returns the unsigned remainder from dividing the first argument by the second
-             * where each argument and the result is interpreted as an unsigned value.
-             *
-             * @param dividend
-             * @param divisor
-             * @throw ArithmeticException if the divisor is zero
-             * @return the unsigned remainder of the first argument divided by the second argument
-             */
-            static int remainderUnsigned(int dividend, int divisor);
-
-            /**
-             * Returns the value obtained by reversing the order
-             * of the bits in the two's complement binary representation
-             * of the specified int value.
-             *
-             * @param inputInt
-             * @return the value obtained by reversing order of the bits in the specified int value.
-             */
-            static int reverse(int inputInt);
-
-            /**
-             * Returns the value obtained by reversing the order of the bytes in the two's complement
-             * representation of the specified int value.
-             *
-             * @param inputInt
-             * @return the value obtained by reversing the bytes in the specified int value.
-             */
-            static int reverseBytes(int inputInt);
-
-            /**
-             * Returns the value obtained by rotating the
-             * two's complement binary representation of
-             * the specified int value left by the specified number of bits
-             *
-             * @param inputInt
-             * @param distance
-             * @return the value obtained by rotating the two's complement binary
-             * representation of the specified int value left by the specified number of bits.
-             */
-            static int rotateLeft(int inputInt, int distance);
-
-            /**
-             * Returns the value obtained by rotating the
-             * two's complement binary representation of
-             * the specified int value right by the specified number of bits
-             *
-             * @param inputInt
-             * @param distance
-             * @return the value obtained by rotating the two's complement binary
-             * representation of the specified int value right by the specified number of bits.
-             */
-            static int rotateRight(int inputInt, int distance);
-
-            /**
-             * Returns the value of this Integer as
-             * a short after a narrowing primitive conversion.
-             *
-             * @return the value of this Integer as a short
-             */
-            short shortValue() const override;
-
-            /**
-             * Returns the signum function of the specified int value.
-             *
-             * @param inputInt
-             * @return the signum function of the specified int value.
-             */
-            static int signum(int inputInt);
-
-            /**
-             * Adds two integers together as per the + operator.
-             *
-             * @param intA
-             * @param intA
-             * @return sum of intA and intB
-             */
-            static int sum(int intA, int intB);
-
-            /**
-             * Returns a string representation of
-             * the integer argument as an unsigned integer in base 2.
-             *
-             * @param inputInt
-             * @return the string representation of the unsigned integer value
-             * represented by the argument in binary
-             */
-            static String toBinaryString(int inputInt);
-
-            /**
-             * Returns a string representation of
-             * the integer argument as an unsigned integer in base 16.
-             *
-             * @param inputInt
-             * @return the string representation of the unsigned integer value
-             * represented by the argument in hex
-             */
-            static String toHexString(int inputInt);
-
-            /**
-             * Returns a string representation of
-             * the integer argument as an unsigned integer in base 8.
-             *
-             * @param inputInt
-             * @return a String representation of the unsigned integer value
-             * represented by the argument in base 8
-             */
-            static String toOctalString(int inputInt);
-
-            /**
-             * Returns a String object
-             * representing the specified integer.
-             *
-             * @param inputInt
-             * @return a String representation of inputInt in base 10.
-             */
-            static String toString(int inputInt);
-
-            /**
-             * Returns a string representation of the first argument in the radix
-             * specified by the second argument.
-             * Support radix 2, 8, 16, 10
-             *
-             * @param inputInt
-             * @param radix
-             * @throw UnsupportedOperationException - if radix is not support
-             * @return a String representation of inputInt in the specified radix.
-             */
-            static String toString(int inputInt, int radix);
-
-            /**
-             * Converts the argument to a long by an unsigned conversion.
-             *
-             * @param longValue
-             * @return the argument converted to long by an unsigned conversion
-             */
-            static long toUnsignedLong(int longValue);
-
-            /**
-             * Returns a string representation of the first argument as an unsigned
-             * integer value in the radix specified by the second argument.
-             * Support radix 2, 8, 16, 10
-             *
-             * @param inputInt
-             * @param radix
-             * @throw UnsupportedOperationException - if radix is not support
-             * @return an unsigned String representation of the argument in the specified radix.
-             */
-            static String toUnsignedString(int inputInt, int radix);
-
-            /**
-             * Returns a string representation of
-             * the argument as an unsigned decimal value.
-             *
-             * @param inputInt
-             * @return an unsigned String representation of the argument.
-             */
-            static String toUnsignedString(int inputInt);
-
-            /**
-             * Returns an Integer object holding the value of the specified String .
-             *
-             * @param inputString
-             * @throw NumberFormatException - if the string cannot be parsed as an integer.
-             * @return an Integer object holding the value represented by the string argument.
-             */
-            static Integer valueOf(String inputString);
-
-            /**
-             * Returns an Integer instance representing the specified int value.
-             *
-             * @param inputInt
-             * @return an Integer instance representing inputInt.
-             */
-            static Integer valueOf(int inputInt);
-
-            /**
-             * Returns an Integer object holding the value extracted from the specified String
-             * when parsed with the radix given by the second argument.
-             *
-             * @param inputString
-             * @param radix
-             * @throw NumberFormatException - if the String does not contain a parsable int.
-             * @return an Integer object holding the value represented by the string argument
-             * in the specified radix.
-             */
-            static Integer valueOf(String inputString, int radix);
-
-            /**
-             * Stream insertion operator
-             *
-             * @param os
-             * @param target
-             * @return ostream
-             */
-            friend std::ostream &operator<<(std::ostream &os, const Integer &target) {
-                std::cout << target.original;
-                return os;
-            }
+		namespace Lang {
+				class Integer;
+				
+				class Integer : public Number, public virtual Comparable<Integer> {
+				private:
+						int original;
+						string originalString;
+				
+				private:
+						/**
+						 * Max value of unsigned int
+						 */
+						static constexpr unsigned int UNSIGNED_INT_MAX = 0xffffffff;
+						
+						/**
+						 * Max value of unsigned int
+						 */
+						static constexpr unsigned int UNSIGNED_INT_MIN = 0;
+				
+				public:
+						/**
+						 * The number of bits used to represent an int value in two's complement binary form.
+						 */
+						static const int SIZE = 32;
+						
+						/**
+						 * The number of bytes used to represent a int value in two's complement binary form.
+						 */
+						// TODO change from 8 to Byte::SIZE
+						static const int BYTES = SIZE / 8;
+						
+						/**
+						 * A constant holding the maximum value of type int
+						 */
+						static constexpr int MAX_VALUE = std::numeric_limits<int>::max();  // 2,147,483,647   2147483647
+						
+						/**
+						 * A constant holding the minimum value of type int
+						 */
+						static constexpr int MIN_VALUE = std::numeric_limits<int>::min();  // –2,147,483,648  –2147483648
+				
+				public:
+						/**
+						 * Integer initialization
+						 *
+						 */
+						Integer();
+						
+						/**
+						 * Integer initialization with specific original value
+						 *
+						 * @param original
+						 */
+						Integer(int original);
+						
+						/**
+						 * Integer initialization with specific original value from String
+						 *
+						 * @param inputString
+						 */
+						Integer(String inputString);
+						
+						/**
+						 * Copy Constructor
+						 *
+						 * @param Integer &target
+						 */
+						Integer(const Integer &target);
+						
+						/**
+						 * Integer Destructor
+						 */
+						~Integer();
+				
+				public:
+						/**
+						 * Integer to Char
+						 *
+						 * @return char
+						 */
+						char charValue() const;
+						
+						/**
+						 * Integer to string
+						 *
+						 * @return string
+						 */
+						string stringValue() const;
+						
+						/**
+						 * Returns a String object representing
+						 * the specified integer.
+						 *
+						 * @return string
+						 */
+						string toString() const override;
+						
+						/**
+						 * Assign value of this object same as target value
+						 *
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator=(const Integer &target);
+						
+						/**
+						 * Compares two Integer objects numerically.
+						 *
+						 * @param  Integer anotherInteger
+						 * @return the value 0 if this Integer is equal to the argument Integer;
+						 * a value less than 0 if this Integer is numerically less than the argument Integer;
+						 * and a value greater than 0 if this Integer is numerically greater than
+						 * the argument Integer (signed comparison).
+						 */
+						int compareTo(const Integer &anotherInteger) const override;
+						
+						/**
+						 * Make a summation with target Integer
+						 *
+						 * @return Integer
+						 */
+						Integer operator+(const Integer &target);
+						
+						/**
+						 * Make a subtraction with target Integer
+						 *
+						 * @return Integer
+						 */
+						Integer operator-(const Integer &target);
+						
+						/**
+						 * Make a division from this Integer with target
+						 *
+						 * @throw ArithmeticException if target is zero
+						 * @return Integer
+						 */
+						Integer operator/(const Integer &target);
+						
+						/**
+						 * Make a multiple from this Integer with target
+						 *
+						 * @return Integer
+						 */
+						Integer operator*(const Integer &target);
+						
+						/**
+						 * Make a modulo from this Integer with target
+						 *
+						 * @throw ArithmeticException if target is zero
+						 * @return Integer
+						 */
+						Integer operator%(const Integer &target);
+						
+						/**
+						 * Compare this Integer is equal to target
+						 *
+						 * @return boolean
+						 */
+						boolean operator==(const Integer &target) const;
+						
+						/**
+						 * Compare this Integer is not equal to target
+						 *
+						 * @return bool
+						 */
+						boolean operator!=(const Integer &target) const;
+						
+						/**
+						 * Compare this Integer is less than target
+						 *
+						 * @return bool
+						 */
+						boolean operator<(const Integer &target) const;
+						
+						/**
+						 * Compare this Integer is more than target
+						 *
+						 * @return bool
+						 */
+						boolean operator>(const Integer &target) const;
+						
+						/**
+						 * Compare this Integer is equal to or less than target
+						 *
+						 * @return bool
+						 */
+						boolean operator<=(const Integer &target) const;
+						
+						/**
+						 * Compare this Integer is equal to
+						 * or greater than target
+						 *
+						 * @return bool
+						 */
+						boolean operator>=(const Integer &target) const;
+						
+						/**
+						 * Add target to this Integer and assign the value to this Integer
+						 *
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator+=(const Integer &target);
+						
+						/**
+						 * Subtract target from this Integer and assign the value to this Integer
+						 *
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator-=(const Integer &target);
+						
+						/**
+						 * Divide this Integer with target and assign the value to this Integer
+						 *
+						 * @throw ArithmeticException if target is zero
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator/=(const Integer &target);
+						
+						/**
+						 * Multiply this Integer with target and assign the value to this Integer
+						 *
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator*=(const Integer &target);
+						
+						/**
+						 * Modulus this Integer with target and assign the value to this Integer
+						 *
+						 * @throw ArithmeticException if target is zero
+						 * @param target
+						 * @return Integer
+						 */
+						Integer &operator%=(const Integer &target);
+						
+						/**
+						 * Returns the number of one-bits in the
+						 * two's complement binary representation
+						 * of the specified int value.
+						 *
+						 * @param inputInt
+						 * @return int
+						 */
+						static int bitCount(int inputInt);
+						
+						/**
+						 * Returns the value of this Integer as a byte
+						 * after a narrowing primitive conversion.
+						 *
+						 * @return byte
+						 */
+						byte byteValue();
+						
+						/**
+						 * Compares two int values numerically.
+						 *
+						 * @param intA
+						 * @param intB
+						 * @return the value 0 if intA == intB; a value less than 0 if intA < intB;
+						 * and a value greater than 0 if intA > intB
+						 */
+						static int compare(int intA, int intB);
+						
+						/**
+						 * Compares two int values numerically
+						 * treating the values as unsigned.
+						 *
+						 * @param intA
+						 * @param intA
+						 * @return the value 0 if intA == intB;
+						 * a value less than 0 if intA < intB as unsigned values;
+						 * and a value greater than 0 if intA > intB as unsigned values
+						 */
+						static int compareUnsigned(int intA, int intB);
+						
+						/**
+						 * Decodes a String into an Integer. Accepts decimal, hexadecimal, and octal numbers
+						 *
+						 * @param inputString
+						 * @throw NumberFormatException - if the String does not contain a parsable integer
+						 * or the String contain a number outside the range of integer
+						 * @return an Integer object holding the int value represented by inputString
+						 */
+						static Integer decode(String inputString);
+						
+						/**
+						 * Returns the unsigned quotient of dividing the first argument by the second
+						 * where each argument and the result is interpreted as an unsigned value
+						 *
+						 * @param dividend
+						 * @param divisor
+						 * @return the unsigned quotient of the first argument divided by the second argument
+						 */
+						static int divideUnsigned(int dividend, int divisor);
+						
+						/**
+						 * Returns the value of this Integer as a double after
+						 * a widening primitive conversion.
+						 *
+						 * @return the value of this Integer as a double
+						 */
+						double doubleValue() const override;
+						
+						/**
+						 * Compares this object to the specified object.
+						 *
+						 * @param object
+						 * @return true if the objects are the same; false otherwise.
+						 */
+						// TODO need instanceof temporary use Integer instead of Object
+						boolean equals(Integer object);
+						
+						/**
+						 * Returns the value of this Integer as
+						 * a float after a widening primitive conversion.
+						 *
+						 * @return the value of this Integer as a float
+						 */
+						float floatValue() const override;
+						
+						/**
+						 * Determines the integer value of the system property with the specified name.
+						 *
+						 * @param propertyName
+						 * @throw SecurityException
+						 * @return the Integer value of the property.
+						 */
+						// Not support this method yet
+						// static Integer getInteger(String propertyName); // TODO(thoangminh): research it
+						
+						/**
+						 * Determines the integer value of the system property with the specified name.
+						 *
+						 * @param propertyName
+						 * @param defaultValue
+						 * @throw SecurityException
+						 * @return the Integer value of the property.
+						 */
+						// Not support this method yet
+						// static Integer getInteger(String propertyName, int defaultValue);
+						
+						/**
+						 * Returns the integer value of the system property with the specified name.
+						 *
+						 * @param propertyName
+						 * @param defaultValue
+						 * @throw SecurityException
+						 * @return Returns the integer value of the system property with the specified name.
+						 */
+						// Not support this method yet
+						// static Integer getInteger(String propertyName, Integer defaultValue);
+						
+						/**
+						 * Returns a hash code for this Integer.
+						 *
+						 * @return hash code of this Integer
+						 * equal to the primitive int value represented by this Integer object.
+						 */
+						long hashCode() const override;
+						
+						/**
+						 * Returns a hash code for a int value;
+						 *
+						 * @param inputInt
+						 * @return a hash code value for inputInt
+						 */
+						static int hashCode(int inputInt);
+						
+						/**
+						 * Returns an int value with at most a single one-bit, in the position of
+						 * the highest-order ("leftmost") one-bit in the specified int value.
+						 *
+						 * @param inputInt
+						 * @return an int value with a single one-bit,
+						 * in the position of the highest-order one-bit in the specified value,
+						 * or zero if the specified value is itself equal to zero.
+						 */
+						static int highestOneBit(int inputInt);
+						
+						/**
+						 * Returns the value of this Integer as an int .
+						 *
+						 * @return the value of this Integer as an int
+						 */
+						int intValue() const override;
+						
+						/**
+						 * Returns the value of this Integer as an long after
+						 * a widening primitive conversion
+						 *
+						 * @return he value of this Integer as an long
+						 */
+						long longValue() const override;
+						
+						/**
+						 * Returns an int value with at most a single one-bit, in the position of
+						 * the lowest-order ("rightmost") one-bit in the specified int value.
+						 *
+						 * @param inputInt
+						 * @return an int value with a single one-bit,
+						 * in the position of the lowest-order one-bit in the specified value,
+						 * or zero if the specified value is itself equal to zero
+						 */
+						static int lowestOneBit(int inputInt);
+						
+						/**
+						 * Returns the greater of two int values
+						 * as if by calling Math::max(int, int).
+						 *
+						 * @param intA
+						 * @param intB
+						 * @return intA if intA >= intB, else intB
+						 */
+						static int max(int intA, int intB);
+						
+						/**
+						 * Returns the smaller of two int values
+						 * as if by calling Math::min(int,int).
+						 *
+						 * @param intA
+						 * @param intB
+						 * @return intA if intA <= intB, else intB
+						 */
+						static int min(int intA, int intB);
+						
+						/**
+						 * Returns the number of zero bits preceding the highest-order
+						 * ("leftmost") one-bit in the two's complement
+						 * binary representation of the specified inputInt.
+						 *
+						 * @param inputInt
+						 * @return the number of zero bits preceding the highest-order ("leftmost") one-bit
+						 * in the two's complement binary representation of the specified int value,
+						 * or 32 if the value is equal to zero.
+						 */
+						static int numberOfLeadingZeros(int inputInt);
+						
+						/**
+						 * Returns the number of zero bits following the lowest-order ("rightmost")
+						 * one-bit in the two's complement binary representation of the specified int value.
+						 *
+						 * @param inputInt
+						 * @return the number of zero bits preceding the highest-order ("leftmost") one-bit
+						 * in the two's complement binary representation of the specified int value,
+						 * or 32 if the value is equal to zero.
+						 */
+						static int numberOfTrailingZeros(int inputInt);
+						
+						/**
+						 * Parses the string argument as
+						 * a signed integer in the radix
+						 * specified by the second argument.
+						 *
+						 * @param inputString
+						 * @param radix
+						 * @throw NumberFormatException if
+						 * The first argument is null or is a string of length zero.
+						 * The radix is either smaller than Character::MIN_RADIX or larger than Character::MAX_RADIX.
+						 * Any character of the string is not a digit of the specified radix,
+						 * The value represented by the string is not a value of type int.
+						 * @return int
+						 */
+						static int parseInt(String inputString, int radix);
+						
+						/**
+						 * Parses the string argument as a signed decimal integer.
+						 *
+						 * @param inputString
+						 * @throw NumberFormatException - if the string does not contain a parsable integer.
+						 * @return the integer value represented by the argument in decimal.
+						 */
+						static int parseInt(String inputString);
+						
+						/**
+						 * Parses the string argument as
+						 * a signed integer in the radix
+						 * specified by the second argument.
+						 *
+						 * @param inputString
+						 * @param radix
+						 * @throw NumberFormatException if
+						 * The first argument is null or is a string of length zero.
+						 * The radix is either smaller than Character::MIN_RADIX or larger than Character::MAX_RADIX.
+						 * Any character of the string is not a digit of the specified radix,
+						 * The value represented by the string is not a value of type unsigned int.
+						 * @return unsigned integer value represented by the argument in decimal
+						 */
+						static int parseUnsignedInt(String inputString, int radix);
+						
+						/**
+						 * Parses the string argument as an unsigned decimal integer
+						 *
+						 * @param inputString
+						 * @throw NumberFormatException - if the string does not contain a parsable unsigned integer.
+						 * @return unsigned integer value represented by the argument in decimal
+						 */
+						static int parseUnsignedInt(String inputString);
+						
+						/**
+						 * Returns the unsigned remainder from dividing the first argument by the second
+						 * where each argument and the result is interpreted as an unsigned value.
+						 *
+						 * @param dividend
+						 * @param divisor
+						 * @throw ArithmeticException if the divisor is zero
+						 * @return the unsigned remainder of the first argument divided by the second argument
+						 */
+						static int remainderUnsigned(int dividend, int divisor);
+						
+						/**
+						 * Returns the value obtained by reversing the order
+						 * of the bits in the two's complement binary representation
+						 * of the specified int value.
+						 *
+						 * @param inputInt
+						 * @return the value obtained by reversing order of the bits in the specified int value.
+						 */
+						static int reverse(int inputInt);
+						
+						/**
+						 * Returns the value obtained by reversing the order of the bytes in the two's complement
+						 * representation of the specified int value.
+						 *
+						 * @param inputInt
+						 * @return the value obtained by reversing the bytes in the specified int value.
+						 */
+						static int reverseBytes(int inputInt);
+						
+						/**
+						 * Returns the value obtained by rotating the
+						 * two's complement binary representation of
+						 * the specified int value left by the specified number of bits
+						 *
+						 * @param inputInt
+						 * @param distance
+						 * @return the value obtained by rotating the two's complement binary
+						 * representation of the specified int value left by the specified number of bits.
+						 */
+						static int rotateLeft(int inputInt, int distance);
+						
+						/**
+						 * Returns the value obtained by rotating the
+						 * two's complement binary representation of
+						 * the specified int value right by the specified number of bits
+						 *
+						 * @param inputInt
+						 * @param distance
+						 * @return the value obtained by rotating the two's complement binary
+						 * representation of the specified int value right by the specified number of bits.
+						 */
+						static int rotateRight(int inputInt, int distance);
+						
+						/**
+						 * Returns the value of this Integer as
+						 * a short after a narrowing primitive conversion.
+						 *
+						 * @return the value of this Integer as a short
+						 */
+						short shortValue() const override;
+						
+						/**
+						 * Returns the signum function of the specified int value.
+						 *
+						 * @param inputInt
+						 * @return the signum function of the specified int value.
+						 */
+						static int signum(int inputInt);
+						
+						/**
+						 * Adds two integers together as per the + operator.
+						 *
+						 * @param intA
+						 * @param intA
+						 * @return sum of intA and intB
+						 */
+						static int sum(int intA, int intB);
+						
+						/**
+						 * Returns a string representation of
+						 * the integer argument as an unsigned integer in base 2.
+						 *
+						 * @param inputInt
+						 * @return the string representation of the unsigned integer value
+						 * represented by the argument in binary
+						 */
+						static String toBinaryString(int inputInt);
+						
+						/**
+						 * Returns a string representation of
+						 * the integer argument as an unsigned integer in base 16.
+						 *
+						 * @param inputInt
+						 * @return the string representation of the unsigned integer value
+						 * represented by the argument in hex
+						 */
+						static String toHexString(int inputInt);
+						
+						/**
+						 * Returns a string representation of
+						 * the integer argument as an unsigned integer in base 8.
+						 *
+						 * @param inputInt
+						 * @return a String representation of the unsigned integer value
+						 * represented by the argument in base 8
+						 */
+						static String toOctalString(int inputInt);
+						
+						/**
+						 * Returns a String object
+						 * representing the specified integer.
+						 *
+						 * @param inputInt
+						 * @return a String representation of inputInt in base 10.
+						 */
+						static String toString(int inputInt);
+						
+						/**
+						 * Returns a string representation of the first argument in the radix
+						 * specified by the second argument.
+						 * Support radix 2, 8, 16, 10
+						 *
+						 * @param inputInt
+						 * @param radix
+						 * @throw UnsupportedOperationException - if radix is not support
+						 * @return a String representation of inputInt in the specified radix.
+						 */
+						static String toString(int inputInt, int radix);
+						
+						/**
+						 * Converts the argument to a long by an unsigned conversion.
+						 *
+						 * @param longValue
+						 * @return the argument converted to long by an unsigned conversion
+						 */
+						static long toUnsignedLong(int longValue);
+						
+						/**
+						 * Returns a string representation of the first argument as an unsigned
+						 * integer value in the radix specified by the second argument.
+						 * Support radix 2, 8, 16, 10
+						 *
+						 * @param inputInt
+						 * @param radix
+						 * @throw UnsupportedOperationException - if radix is not support
+						 * @return an unsigned String representation of the argument in the specified radix.
+						 */
+						static String toUnsignedString(int inputInt, int radix);
+						
+						/**
+						 * Returns a string representation of
+						 * the argument as an unsigned decimal value.
+						 *
+						 * @param inputInt
+						 * @return an unsigned String representation of the argument.
+						 */
+						static String toUnsignedString(int inputInt);
+						
+						/**
+						 * Returns an Integer object holding the value of the specified String .
+						 *
+						 * @param inputString
+						 * @throw NumberFormatException - if the string cannot be parsed as an integer.
+						 * @return an Integer object holding the value represented by the string argument.
+						 */
+						static Integer valueOf(String inputString);
+						
+						/**
+						 * Returns an Integer instance representing the specified int value.
+						 *
+						 * @param inputInt
+						 * @return an Integer instance representing inputInt.
+						 */
+						static Integer valueOf(int inputInt);
+						
+						/**
+						 * Returns an Integer object holding the value extracted from the specified String
+						 * when parsed with the radix given by the second argument.
+						 *
+						 * @param inputString
+						 * @param radix
+						 * @throw NumberFormatException - if the String does not contain a parsable int.
+						 * @return an Integer object holding the value represented by the string argument
+						 * in the specified radix.
+						 */
+						static Integer valueOf(String inputString, int radix);
+						
+						/**
+						 * Stream insertion operator
+						 *
+						 * @param os
+						 * @param target
+						 * @return ostream
+						 */
+						friend std::ostream &operator<<(std::ostream &os, const Integer &target) {
+							std::cout << target.original;
+							return os;
+						}
+						
+						inline size_t operator()(const Integer &target) const {
+							String targetString = target.toString();
+							return std::_Hash_impl::hash(targetString.toString(), targetString.length());
+						}
+				};
+		}
+}
+
+namespace std {
+		template <> struct hash<Integer> {
+				std::size_t operator()(const Integer& k) const {
+					return Integer()(k);
+				}
 		};
-	}
 }
 
 #endif  // JAVA_LANG_INTEGER_HPP

--- a/java/lang/Long/Long.hpp
+++ b/java/lang/Long/Long.hpp
@@ -522,14 +522,29 @@ namespace Java {
 						 * @param target
 						 */
 						void operator%=(const Long &target);
-				
+						
 				public:
 						friend std::ostream &operator<<(std::ostream &os, const Long &target) {
 							os << target.original;
 							return os;
 						}
+						
+						inline size_t operator()(const Long &target) const {
+							String targetLong = target.toString();
+							return std::_Hash_impl::hash(targetLong.toString(), targetLong.length());
+						}
 				};
 		}
+}
+
+using namespace Java::Lang;
+
+namespace std {
+		template <> struct hash<Long> {
+				std::size_t operator()(const Long& k) const {
+					return Long()(k);
+				}
+		};
 }
 
 #endif  // JAVA_LANG__HPP

--- a/java/lang/Object/ObjectTest.cpp
+++ b/java/lang/Object/ObjectTest.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "../../../kernel/Test.hpp"
-#include "../../util/HashMap/HashMap.hpp"
 
 using namespace Java::Lang;
 
@@ -102,14 +101,6 @@ TEST (JavaLang, DataTypeArray) {
 	// Retrieve  elements from an existing array
 	assertEquals("Food", initializedStrings.get(0).toString());
 	assertEquals("Tiny", initializedStrings.get(1).toString());
-	
-	Array<HashMap<String, String>*> arrayHashMap;
-	HashMap<String, String> hashMap;
-	hashMap.put("Key1", "Value1");
-	arrayHashMap.push(&hashMap);
-	for (auto hashMap : arrayHashMap) {
-		assertEquals("Value1", hashMap->get("Key1").toString());
-	}
 }
 
 TEST (JavaLang, ArrayConstructorWithSize) {

--- a/java/lang/Short/Short.hpp
+++ b/java/lang/Short/Short.hpp
@@ -81,8 +81,21 @@ namespace Java {
 							os << target.original;
 							return os;
 						}
+						
+						inline size_t operator()(const Short &target) const {
+							String targetString = target.toString();
+							return std::_Hash_impl::hash(targetString.toString(), targetString.length());
+						}
 				};
 		}
+}
+
+namespace std {
+		template <> struct hash<Short> {
+				std::size_t operator()(const Short& k) const {
+					return Short()(k);
+				}
+		};
 }
 
 #endif  // JAVA_LANG_SHORT_SHORT_HPP

--- a/java/lang/String/String.hpp
+++ b/java/lang/String/String.hpp
@@ -1120,7 +1120,10 @@ namespace Java {
             inline boolean operator>=(const String &target) const {
                 return strcmp(this->original, target.toString()) >= 0;
             }
-
+        
+            inline size_t operator()(const String &target) const {
+                  return std::_Hash_impl::hash(target.original, target.length());
+            }
         public:
             /**
              * Format string
@@ -1269,5 +1272,15 @@ namespace Java {
         };
     } // namespace Lang
 } // namespace Java
+
+using namespace Java::Lang;
+
+namespace std {
+        template <> struct hash<String> {
+                std::size_t operator()(const String& k) const {
+                    return String()(k);
+                }
+        };
+}
 
 #endif  // JAVA_LANG_STRING_STRING_HPP

--- a/java/util/HashMap/HashMap.hpp
+++ b/java/util/HashMap/HashMap.hpp
@@ -29,11 +29,11 @@
 
 #include <initializer_list>
 #include <iostream>
+#include <unordered_map>
 #include "../../lang/String/String.hpp"
 #include "../AbstractMap/AbstractMap.hpp"
 #include "../Map/Map.hpp"
 #include "../Set/Set.hpp"
-#include <map>
 #include <functional>
 
 namespace Java {
@@ -46,10 +46,10 @@ namespace Java {
                 public virtual Serializable {
 
         private:
-            std::map<Key, Value> original;
+            std::unordered_map<Key, Value> original;
             String backup;
-            typedef typename std::map<Key, Value>::iterator IteratorType;
-            typedef typename std::map<Key, Value>::const_iterator ConstIteratorType;
+            typedef typename std::unordered_map<Key, Value>::iterator IteratorType;
+            typedef typename std::unordered_map<Key, Value>::const_iterator ConstIteratorType;
 
         public:
             /**
@@ -224,7 +224,7 @@ namespace Java {
              * Called by clone and readObject.
              */
             void reinitialize() {
-                std::map<Key, Value> newMap;
+                std::unordered_map<Key, Value> newMap;
                 this->original = newMap;
             }
 
@@ -686,7 +686,7 @@ namespace Java {
                 String endString = "}";
                 String totalString;
 
-                typename std::map<Key, Value>::iterator it;
+                typename std::unordered_map<Key, Value>::iterator it;
                 for (it = this->original.begin(); it != this->original.end(); ++it) {
                     if (instanceof<String>(it->first)) {
                         String first = it->first.toString();

--- a/java/util/HashMap/HashMapTest.cpp
+++ b/java/util/HashMap/HashMapTest.cpp
@@ -25,524 +25,515 @@
  */
 
 #include "../../../kernel/Test.hpp"
-#include "../../Lang.hpp"
 #include "HashMap.hpp"
-#include "../ArrayList/ArrayList.hpp"
 
 using namespace Java::Lang;
 using namespace Java::Util;
 
 TEST (JavaUtil, HashMapConstructor) {
-    String expected;
-    String actual;
-
-    // Test default constructor
-    HashMap<String, Integer> emptyHashMap;
-
-    // Make sure emptyHashMap is empty
-    assertTrue(emptyHashMap.isEmpty());
-
-    // Test copy constructor
-    HashMap<String, String> container;
-    container.put("sample", "here");
-    container.put("key", "value");
-
-    HashMap<String, String> hashMap = container;
-
-    // Test valid size()
-    assertEquals(2, hashMap.size());
-    assertFalse(hashMap.isEmpty());
-
-    // Test valid data between hashMap and container
-    expected = container.get("sample");
-    actual = hashMap.get("sample");
-
-    assertFalse(expected.isEmpty());
-    assertFalse(actual.isEmpty());
-    assertEquals(expected.toString(), actual.toString());
-
-    expected = container.get("key");
-    actual = hashMap.get("key");
-
-    assertFalse(expected.isEmpty());
-    assertFalse(actual.isEmpty());
-    assertEquals(expected.toString(), actual.toString());
+	String expected;
+	String actual;
+	
+	// Test default constructor
+	HashMap<String, Integer> emptyHashMap;
+	
+	// Make sure emptyHashMap is empty
+	assertTrue(emptyHashMap.isEmpty());
+	
+	// Test copy constructor
+	HashMap<String, String> container;
+	container.put("sample", "here");
+	container.put("key", "value");
+	
+	HashMap<String, String> hashMap = container;
+	
+	// Test valid size()
+	assertEquals(2, hashMap.size());
+	assertFalse(hashMap.isEmpty());
+	
+	// Test valid data between hashMap and container
+	expected = container.get("sample");
+	actual = hashMap.get("sample");
+	
+	assertFalse(expected.isEmpty());
+	assertFalse(actual.isEmpty());
+	assertEquals(expected.toString(), actual.toString());
+	
+	expected = container.get("key");
+	actual = hashMap.get("key");
+	
+	assertFalse(expected.isEmpty());
+	assertFalse(actual.isEmpty());
+	assertEquals(expected.toString(), actual.toString());
 }
 
 TEST (JavaUtil, HashMapClear) {
-    // Given valid hashMap to test clear()
-    HashMap<Long, Integer> hashMap;
-    hashMap.put((long) 100, 25);
-    hashMap.put((long) 500, 123);
-    assertEquals(2, hashMap.size());
-
-    hashMap.clear();
-    assertEquals(0, hashMap.size());
+	// Given valid hashMap to test clear()
+	HashMap<Long, Integer> hashMap;
+	hashMap.put((long) 100, 25);
+	hashMap.put((long) 500, 123);
+	assertEquals(2, hashMap.size());
+	
+	hashMap.clear();
+	assertEquals(0, hashMap.size());
 }
 
 TEST (JavaUtil, HashMapClone) {
-    String actualKey;
-    String expected;
-    String actual;
-
-    // Create a HashMap to test to test clone()
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "Value of Key1");
-    hashMap.put("Key2", "Value of Key2");
-    HashMap<String, String> anotherMap = hashMap.clone();
-
-    // Test actualKey = "Key1" is exist in anotherMap
-    actualKey = "Key1";
-    expected = "Value of Key1";
-    actual = anotherMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Test actualKey = "Key2" is exist in anotherMap
-    actualKey = "Key2";
-    expected = "Value of Key2";
-    actual = anotherMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Test non-exist key
-    actualKey = "wrong key";
-    actual = anotherMap.get(actualKey);
-    assertTrue(actual.isEmpty());
+	String actualKey;
+	String expected;
+	String actual;
+	
+	// Create a HashMap to test to test clone()
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value of Key1");
+	hashMap.put("Key2", "Value of Key2");
+	HashMap<String, String> anotherMap = hashMap.clone();
+	
+	// Test actualKey = "Key1" is exist in anotherMap
+	actualKey = "Key1";
+	expected = "Value of Key1";
+	actual = anotherMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Test actualKey = "Key2" is exist in anotherMap
+	actualKey = "Key2";
+	expected = "Value of Key2";
+	actual = anotherMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Test non-exist key
+	actualKey = "wrong key";
+	actual = anotherMap.get(actualKey);
+	assertTrue(actual.isEmpty());
 }
 
 TEST (JavaUtil, HashMapContainsKey) {
-    boolean actual;
-
-    // Create a HashMap to test
-    HashMap<Integer, String> hashMap;
-    hashMap.put(3, "three");
-    hashMap.put(17, "seven teen");
-    hashMap.put(-52, "negative fifty two");
-
-    // Valid key
-    actual = hashMap.containsKey(-52);
-    assertTrue(actual);
-
-    // Invalid key
-    actual = hashMap.containsKey(100);
-    assertFalse(actual);
+	boolean actual;
+	
+	// Create a HashMap to test
+	HashMap<Integer, String> hashMap;
+	hashMap.put(3, "three");
+	hashMap.put(17, "seven teen");
+	hashMap.put(-52, "negative fifty two");
+	
+	// Valid key
+	actual = hashMap.containsKey(-52);
+	assertTrue(actual);
+	
+	// Invalid key
+	actual = hashMap.containsKey(100);
+	assertFalse(actual);
 }
 
 TEST (JavaUtil, HashMapContainsValue) {
-    boolean actual;
-
-    // Create a HashMap to test
-    HashMap<String, Double> hashMap;
-    hashMap.put("15.3", 15.3);
-    hashMap.put("30.111", 30.111);
-
-    // Valid key
-    actual = hashMap.containsValue(15.3);
-    assertTrue(actual);
-
-    // Invalid key
-    actual = hashMap.containsValue(30.22);
-    assertFalse(actual);
+	boolean actual;
+	
+	// Create a HashMap to test
+	HashMap<String, Double> hashMap;
+	hashMap.put("15.3", 15.3);
+	hashMap.put("30.111", 30.111);
+	
+	// Valid key
+	actual = hashMap.containsValue(15.3);
+	assertTrue(actual);
+	
+	// Invalid key
+	actual = hashMap.containsValue(30.22);
+	assertFalse(actual);
 }
 
 TEST (JavaUtil, HashMapEntrySet) {
-    HashMap<String, String> hashMap;
-    int index = 1;
-    for (index; index <= 100; index++) {
-        hashMap.put("Key " + String::valueOf(index),
-                    "Value " + String::valueOf(index));
-    }
-    int counter = 0;
-    Set<class Map<String, String>::Entry> entrySet = hashMap.entrySet();
-    // TODO - loint@foodtiny.com will improve entrySet
-    // then we can put it inside foreach without any performance issue
-    for (Map<String, String>::Entry entry : entrySet) {
-        counter += 1;
-        if (counter == 1) {
-            assertEquals("Key 99", entry.getKey().toString());
-            assertEquals("Value 99", entry.getValue().toString());
-        }
-        if (counter == 2) {
-            assertEquals("Key 98", entry.getKey().toString());
-            assertEquals("Value 98", entry.getValue().toString());
-        }
-    }
-    // Make sure foreach is working
-    assertEquals(100, counter);
-    
-    HashMap<String, String*> hashMapStringPointer;
-    hashMapStringPointer.put("test1", new String("test1"));
-    hashMapStringPointer.put("test2", new String("test1"));
-    hashMapStringPointer.put("test3", new String("test1"));
-	for (Map<String, String*>::Entry entry : hashMapStringPointer.entrySet()) {
+	HashMap<String, String> hashMap;
+	int index = 1;
+	for (index; index <= 100; index++) {
+		hashMap.put("Key test" + String::valueOf(index), "Value test");
+	}
+	
+	int counter = 0;
+	Set<class Map<String, String>::Entry> entrySet = hashMap.entrySet();
+	// TODO - loint@foodtiny.com will improve entrySet
+	// then we can put it inside foreach without any performance issue
+	for (Map<String, String>::Entry entry : entrySet) {
+		counter += 1;
+	}
+	
+	// Make sure foreach is working
+	assertEquals(100, counter);
+	
+	HashMap<String, String *> hashMapStringPointer;
+	hashMapStringPointer.put("test1", new String("test1"));
+	hashMapStringPointer.put("test2", new String("test1"));
+	hashMapStringPointer.put("test3", new String("test1"));
+	for (Map<String, String *>::Entry entry : hashMapStringPointer.entrySet()) {
 		assertEquals("test1", entry.getValue()->toString());
-        String *stringValue = entry.getValue();
-        delete stringValue;
+		String *stringValue = entry.getValue();
+		delete stringValue;
 	}
 }
 
 TEST (JavaUtil, HashMapGet) {
-    String expected;
-    String actual;
-
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("key", "value");
-
-    // Valid key
-    expected = "value";
-    actual = hashMap.get("key");
-    assertEquals(expected.toString(), actual.toString());
-
-    // Invalid key
-    actual = hashMap.get("wrong_key");
-    assertTrue(actual.isEmpty());
+	String expected;
+	String actual;
+	
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("key", "value");
+	
+	// Valid key
+	expected = "value";
+	actual = hashMap.get("key");
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Invalid key
+	actual = hashMap.get("wrong_key");
+	assertTrue(actual.isEmpty());
 }
 
 TEST (JavaUtil, HashMapIsEmpty) {
-    // Create a HashMap to test
-    HashMap<String, Float> hashMap;
-
-    // Empty case
-    boolean actual = hashMap.isEmpty();
-    assertTrue(actual);
-
-    // Not empty case
-    hashMap.put("Key1", (float) 123.33);
-    assertFalse(hashMap.isEmpty());
+	// Create a HashMap to test
+	HashMap<String, Float> hashMap;
+	
+	// Empty case
+	boolean actual = hashMap.isEmpty();
+	assertTrue(actual);
+	
+	// Not empty case
+	hashMap.put("Key1", (float) 123.33);
+	assertFalse(hashMap.isEmpty());
 }
 
 TEST (JavaUtil, HashMapPut) {
-    String expected;
-    String actual;
-
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("abc", "Value of Key1");
-    hashMap.put("some key here", "456");
-
-    // Make sure hashMap is not null
-    assertEquals(2, hashMap.size());
-
-    // Make sure the data is safe
-    // Valid key
-    expected = "Value of Key1";
-    actual = hashMap.get("abc");
-    assertEquals(expected.toString(), actual.toString());
-
-    // Valid key
-    expected = "456";
-    actual = hashMap.get("some key here");
-    assertEquals(expected.toString(), actual.toString());
+	String expected;
+	String actual;
+	
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("abc", "Value of Key1");
+	hashMap.put("some key here", "456");
+	
+	// Make sure hashMap is not null
+	assertEquals(2, hashMap.size());
+	
+	// Make sure the data is safe
+	// Valid key
+	expected = "Value of Key1";
+	actual = hashMap.get("abc");
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Valid key
+	expected = "456";
+	actual = hashMap.get("some key here");
+	assertEquals(expected.toString(), actual.toString());
 }
 
 TEST (JavaUtil, HashMapPutAll) {
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("some string", "Value of Key1");
-    hashMap.put("another key", "777");
-    hashMap.put("#!@#another", "-123");
-
-    // putAll data of hashMap to targetMap
-    HashMap<String, String> targetMap;
-    targetMap.putAll(hashMap);
-
-    // Make sure both are the same size
-    assertEquals(hashMap.size(), targetMap.size());
-
-    // Make sure both have the same data
-    String actualKey = "#!@#another";
-    String expected = hashMap.get(actualKey);
-    String actual = targetMap.get(actualKey);
-    assertEquals(actual.toString(), expected.toString());
-
-    actualKey = "some string";
-    expected = hashMap.get(actualKey);
-    actual = targetMap.get(actualKey);
-    assertEquals(actual.toString(), expected.toString());
-
-    actualKey = "another key";
-    expected = hashMap.get(actualKey);
-    actual = targetMap.get(actualKey);
-    assertEquals(actual.toString(), expected.toString());
-
-    // Invalid case
-    actualKey = "some wrong key here";
-    expected = hashMap.get(actualKey);
-    actual = targetMap.get(actualKey);
-    assertTrue(expected.isEmpty());
-    assertTrue(actual.isEmpty());
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("some string", "Value of Key1");
+	hashMap.put("another key", "777");
+	hashMap.put("#!@#another", "-123");
+	
+	// putAll data of hashMap to targetMap
+	HashMap<String, String> targetMap;
+	targetMap.putAll(hashMap);
+	
+	// Make sure both are the same size
+	assertEquals(hashMap.size(), targetMap.size());
+	
+	// Make sure both have the same data
+	String actualKey = "#!@#another";
+	String expected = hashMap.get(actualKey);
+	String actual = targetMap.get(actualKey);
+	assertEquals(actual.toString(), expected.toString());
+	
+	actualKey = "some string";
+	expected = hashMap.get(actualKey);
+	actual = targetMap.get(actualKey);
+	assertEquals(actual.toString(), expected.toString());
+	
+	actualKey = "another key";
+	expected = hashMap.get(actualKey);
+	actual = targetMap.get(actualKey);
+	assertEquals(actual.toString(), expected.toString());
+	
+	// Invalid case
+	actualKey = "some wrong key here";
+	expected = hashMap.get(actualKey);
+	actual = targetMap.get(actualKey);
+	assertTrue(expected.isEmpty());
+	assertTrue(actual.isEmpty());
 }
 
 TEST (JavaUtil, HashMapPutIfAbsent) {
-    String actualKey;
-    String expected;
-    String actual;
-
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("abc", "Value of Key1");
-
-    // Make sure the data is right before test
-    actualKey = "abc";
-    expected = "Value of Key1";
-    actual = hashMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Existent key
-    expected = "Value of Key1";
-    actual = hashMap.putIfAbsent(actualKey, "other value");
-    assertEquals(expected.toString(), actual.toString());
-
-    // Make sure the value is not changed.
-    expected = "Value of Key1";
-    actual = hashMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Non-existent key
-    String wrongKey = "wrong key";
-    expected = "something here";
-    String isSucceedPutIfAbsent = hashMap.putIfAbsent(wrongKey, "something here");
-    actual = hashMap.get(wrongKey);
-    assertTrue(isSucceedPutIfAbsent.isEmpty());
-    assertEquals(expected.toString(), actual.toString());
+	String actualKey;
+	String expected;
+	String actual;
+	
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("abc", "Value of Key1");
+	
+	// Make sure the data is right before test
+	actualKey = "abc";
+	expected = "Value of Key1";
+	actual = hashMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Existent key
+	expected = "Value of Key1";
+	actual = hashMap.putIfAbsent(actualKey, "other value");
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Make sure the value is not changed.
+	expected = "Value of Key1";
+	actual = hashMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Non-existent key
+	String wrongKey = "wrong key";
+	expected = "something here";
+	String isSucceedPutIfAbsent = hashMap.putIfAbsent(wrongKey, "something here");
+	actual = hashMap.get(wrongKey);
+	assertTrue(isSucceedPutIfAbsent.isEmpty());
+	assertEquals(expected.toString(), actual.toString());
 }
 
 TEST (JavaUtil, HashMapRemoveKey) {
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "!@#!@#");
-    hashMap.put("another key", "1111");
-
-    // Make sure the size is right
-    assertEquals(2, hashMap.size());
-
-    // Make sure the data is right
-    String expected = "1111";
-    String actual = hashMap.get("another key");
-    assertEquals(expected.toString(), actual.toString());
-
-    // Data must be removed after removing
-    String isSucceedRemove = hashMap.remove("another key");
-    expected = "1111";
-    assertEquals(expected.toString(), isSucceedRemove.toString());
-
-    // Size must decrease after removing
-    assertEquals(1, hashMap.size());
-
-    // Make sure the old data must not exist any more
-    actual = hashMap.get("another key");
-    assertTrue(actual.isEmpty());
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "!@#!@#");
+	hashMap.put("another key", "1111");
+	
+	// Make sure the size is right
+	assertEquals(2, hashMap.size());
+	
+	// Make sure the data is right
+	String expected = "1111";
+	String actual = hashMap.get("another key");
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Data must be removed after removing
+	String isSucceedRemove = hashMap.remove("another key");
+	expected = "1111";
+	assertEquals(expected.toString(), isSucceedRemove.toString());
+	
+	// Size must decrease after removing
+	assertEquals(1, hashMap.size());
+	
+	// Make sure the old data must not exist any more
+	actual = hashMap.get("another key");
+	assertTrue(actual.isEmpty());
 }
 
 TEST (JavaUtil, HashMapRemoveKeyValue) {
-    // Create a HashMap to test
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "Value of Key1");
-    hashMap.put("another key", "456");
-
-    // Make sure the size is right before removing
-    assertEquals(2, hashMap.size());
-
-    // Make sure the data is right before removing
-    String expectedactual = "Value of Key1";
-    String actual = hashMap.get("Key1");
-    assertEquals(expectedactual.toString(), actual.toString());
-
-    // Invalid case: right case, wrong value
-    boolean isSucceedRemove = hashMap.remove("Key1", "456");
-    assertFalse(isSucceedRemove);
-
-    // Test remove true by key mapped to specified value
-    isSucceedRemove = hashMap.remove("Key1", "Value of Key1");
-    assertTrue(isSucceedRemove);
+	// Create a HashMap to test
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value of Key1");
+	hashMap.put("another key", "456");
+	
+	// Make sure the size is right before removing
+	assertEquals(2, hashMap.size());
+	
+	// Make sure the data is right before removing
+	String expectedactual = "Value of Key1";
+	String actual = hashMap.get("Key1");
+	assertEquals(expectedactual.toString(), actual.toString());
+	
+	// Invalid case: right case, wrong value
+	boolean isSucceedRemove = hashMap.remove("Key1", "456");
+	assertFalse(isSucceedRemove);
+	
+	// Test remove true by key mapped to specified value
+	isSucceedRemove = hashMap.remove("Key1", "Value of Key1");
+	assertTrue(isSucceedRemove);
 }
 
 TEST (JavaUtil, HashMapReplaceKeyValue) {
-    // Create a HashMap to test to test
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "value");
-    hashMap.put("key !@#", "1000");
-    hashMap.put(".;;',", "ab232");
-
-    // Make sure the data is right before replacing
-    String actualKey = ".;;',";
-    String expected = "ab232";
-    String actual = hashMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Replace the oldValue
-    String oldValue = "ab232";
-    String newValue = "250008";
-    String actualReplace = hashMap.replace(actualKey, newValue);
-    assertEquals(oldValue.toString(), actualReplace.toString());
-
-    // Make sure the old value is replaced by new value
-    expected = newValue;
-    actual = hashMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Test non-existent key
-    actualKey = "Non-existent key";
-    actualReplace = hashMap.replace(actualKey, newValue);
-    assertEquals("", actualReplace.toString());
-
+	// Create a HashMap to test to test
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "value");
+	hashMap.put("key !@#", "1000");
+	hashMap.put(".;;',", "ab232");
+	
+	// Make sure the data is right before replacing
+	String actualKey = ".;;',";
+	String expected = "ab232";
+	String actual = hashMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Replace the oldValue
+	String oldValue = "ab232";
+	String newValue = "250008";
+	String actualReplace = hashMap.replace(actualKey, newValue);
+	assertEquals(oldValue.toString(), actualReplace.toString());
+	
+	// Make sure the old value is replaced by new value
+	expected = newValue;
+	actual = hashMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Test non-existent key
+	actualKey = "Non-existent key";
+	actualReplace = hashMap.replace(actualKey, newValue);
+	assertEquals("", actualReplace.toString());
+	
 }
 
 TEST (JavaUtil, HashMapReplaceKeyOldValueNewValue) {
-    // Create a HashMap to test to test
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "Value of Key1");
-    hashMap.put("key123", "!@#");
-
-    // Make sure the size is right
-    assertEquals(2, hashMap.size());
-
-    // Make sure the data is right
-    String actualKey = "key123";
-    String expected = "!@#";
-    String actual = hashMap.get(actualKey);
-    assertEquals(expected.toString(), actual.toString());
-
-    // Replace the old value
-    String key = "key123";
-    String oldValue = "!@#";
-    String newValue = "456";
-    boolean isSucceedReplace = hashMap.replace(key, oldValue, newValue);
-    assertTrue(isSucceedReplace);
-
-    // Make sure the old value is replace by new value
-    actual = hashMap.get(key);
-    assertEquals(newValue.toString(), actual.toString());
-
-    // Replace with incorrect key/oldValue
-    key = "Key1";
-    oldValue = "wrong value";
-    newValue = "newValue";
-    isSucceedReplace = hashMap.replace(key, oldValue, newValue);
-    assertFalse(isSucceedReplace);
-
-    // Make sure the value is not change if replacing is failed
-    key = "Key1";
-    oldValue = "Value of Key1";
-    actual = hashMap.get(key);
-    assertEquals(oldValue.toString(), actual.toString());
+	// Create a HashMap to test to test
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value of Key1");
+	hashMap.put("key123", "!@#");
+	
+	// Make sure the size is right
+	assertEquals(2, hashMap.size());
+	
+	// Make sure the data is right
+	String actualKey = "key123";
+	String expected = "!@#";
+	String actual = hashMap.get(actualKey);
+	assertEquals(expected.toString(), actual.toString());
+	
+	// Replace the old value
+	String key = "key123";
+	String oldValue = "!@#";
+	String newValue = "456";
+	boolean isSucceedReplace = hashMap.replace(key, oldValue, newValue);
+	assertTrue(isSucceedReplace);
+	
+	// Make sure the old value is replace by new value
+	actual = hashMap.get(key);
+	assertEquals(newValue.toString(), actual.toString());
+	
+	// Replace with incorrect key/oldValue
+	key = "Key1";
+	oldValue = "wrong value";
+	newValue = "newValue";
+	isSucceedReplace = hashMap.replace(key, oldValue, newValue);
+	assertFalse(isSucceedReplace);
+	
+	// Make sure the value is not change if replacing is failed
+	key = "Key1";
+	oldValue = "Value of Key1";
+	actual = hashMap.get(key);
+	assertEquals(oldValue.toString(), actual.toString());
 }
 
 TEST (JavaUtil, HashMapSize) {
-    // Create a HashMap to test
-    HashMap<Double, String> hashMap;
-    hashMap.put(15.22222, "15.22222");
-    hashMap.put(-50.2222, "50");
-
-    // Make sure the size is 2
-    assertEquals(2, hashMap.size());
-
-    // Add one more key/value and check size again
-    hashMap.put((double) 123, "some thing here");
-    assertEquals(3, hashMap.size());
+	// Create a HashMap to test
+	HashMap<Double, String> hashMap;
+	hashMap.put(15.22222, "15.22222");
+	hashMap.put(-50.2222, "50");
+	
+	// Make sure the size is 2
+	assertEquals(2, hashMap.size());
+	
+	// Add one more key/value and check size again
+	hashMap.put((double) 123, "some thing here");
+	assertEquals(3, hashMap.size());
 }
 
 TEST (JavaUtil, HashMapToString) {
-    // Given some valid key/value to test toString()
-    HashMap<String, String> hashMap;
-    hashMap.put("key1", "value1");
-    hashMap.put("key16", "value16");
-    hashMap.put("key02", "value02");
-
-    string expectedResult = (string) R"({"key02": "value02", "key1": "value1", "key16": "value16"})";
-    string result = hashMap.toString();
-    assertEquals(expectedResult, result);
-
-    // Given another hash map type to test
-    HashMap<Integer, Integer> anotherHashMap;
-    anotherHashMap.put(1, 12313);
-    anotherHashMap.put(2, 76767);
-
-    expectedResult = (string) R"({1: 12313, 2: 76767})";
-    result = anotherHashMap.toString();
-    assertEquals(expectedResult, result);
-
-    // Given empty hash map to test default toString()
-    HashMap<String, Float> emptyHashMap;
-    expectedResult = (string) "{}";
-    result = emptyHashMap.toString();
-    assertEquals(expectedResult, result);
-
-    ArrayList<Integer> validArrayListInteger1 = {1, 2, 3, 4, 5};
-    ArrayList<Integer> validArrayListInteger2 = {100, 100, 100, 100, 1};
-    HashMap<String, ArrayList<Integer>> arrayListInHashMap;
-    arrayListInHashMap.put("ArrayList1", validArrayListInteger1);
-    arrayListInHashMap.put("ArrayList2", validArrayListInteger2);
-    expectedResult = (string) R"({"ArrayList1": [1, 2, 3, 4, 5], "ArrayList2": [100, 100, 100, 100, 1]})";
-    result = arrayListInHashMap.toString();
-    assertEquals(expectedResult, result);
-
-    // Test HashMap::toString with HashMap has String (key or value) that come from another HashMap::toString()
-    HashMap<String, String> result2;
-
-    result2.put("firstName", "firstName");
-    result2.put("lastName", "lastName");
-    result2.put("birthday", "birthday");
-    result2.put("avatar", "avatar");
-    result2.put("gender", "gender");
-    result2.put("email", "email");
-
-    HashMap<String, String> result3;
-
-    result3.put("Status", "true");
-    result3.put("Infor", result2.toString());
-
-    expectedResult = (string) R"({"Infor": {"avatar": "avatar", "birthday": "birthday", "email": "email", "firstName": "firstName", "gender": "gender", "lastName": "lastName"}, "Status": "true"})";
-    assertEquals(expectedResult, result3.toString());
+	// Given some valid key/value to test toString()
+	HashMap<String, String> hashMap;
+	hashMap.put("key1", "value1");
+	hashMap.put("key16", "value16");
+	hashMap.put("key02", "value02");
+	
+	string expectedResult = (string) R"({"key02": "value02", "key1": "value1", "key16": "value16"})";
+	string result = hashMap.toString();
+	assertEquals(expectedResult, result);
+	
+	// Given another hash map type to test
+	HashMap<Integer, Integer> anotherHashMap;
+	anotherHashMap.put(1, 12313);
+	anotherHashMap.put(2, 76767);
+	
+	expectedResult = (string) R"({2: 76767, 1: 12313})";
+	result = anotherHashMap.toString();
+	assertEquals(expectedResult, result);
+	
+	// Given empty hash map to test default toString()
+	HashMap<String, Float> emptyHashMap;
+	expectedResult = (string) "{}";
+	result = emptyHashMap.toString();
+	assertEquals(expectedResult, result);
+	
+	ArrayList<Integer> validArrayListInteger1 = { 1, 2, 3, 4, 5 };
+	ArrayList<Integer> validArrayListInteger2 = { 100, 100, 100, 100, 1 };
+	HashMap<String, ArrayList<Integer>> arrayListInHashMap;
+	arrayListInHashMap.put("ArrayList1", validArrayListInteger1);
+	arrayListInHashMap.put("ArrayList2", validArrayListInteger2);
+	expectedResult = (string) R"({"ArrayList2": [100, 100, 100, 100, 1], "ArrayList1": [1, 2, 3, 4, 5]})";
+	result = arrayListInHashMap.toString();
+	assertEquals(expectedResult, result);
+	
+	// Test HashMap::toString with HashMap has String (key or value) that come from another HashMap::toString()
+	HashMap<String, String> result2;
+	
+	result2.put("firstName", "firstName");
+	result2.put("lastName", "lastName");
+	result2.put("birthday", "birthday");
+	result2.put("avatar", "avatar");
+	result2.put("gender", "gender");
+	result2.put("email", "email");
+	
+	HashMap<String, String> result3;
+	
+	result3.put("Status", "true");
+	result3.put("Info", result2.toString());
+	
+	expectedResult = (string) R"({"Info": {"email": "email", "avatar": "avatar", "birthday": "birthday", "gender": "gender", "firstName": "firstName", "lastName": "lastName"}, "Status": "true"})";
+	assertEquals(expectedResult, result3.toString());
 }
 
 TEST (JavaUtil, HashMapEquals) {
-    // Create a HashMap
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "Value of Key1");
-    hashMap.put("Key2", "Value of Key2");
-
-    // Create an other HashMap with the same data
-    HashMap<String, String> sameHashMap;
-    sameHashMap.put("Key1", "Value of Key1");
-    sameHashMap.put("Key2", "Value of Key2");
-
-    // Create an other HashMap with the different key
-    HashMap<String, String> differentKeyHashMap;
-    differentKeyHashMap.put("different key", "Value of Key1");
-    differentKeyHashMap.put("Key2", "Value of Key2");
-
-    // Create an other HashMap with the different value
-    HashMap<String, String> differentValueHashMap;
-    differentValueHashMap.put("Key1", "different value");
-    differentValueHashMap.put("Key2", "Value of Key2");
-
-    // Create an other HashMap with the different size
-    HashMap<String, String> differentSizeHashMap;
-    differentSizeHashMap.put("different key", "Value of Key1");
-
-    // Test valid case
-    assertTrue(hashMap.equals(sameHashMap));
-
-    // Test invalid case
-    assertFalse(hashMap.equals(differentKeyHashMap));
-    assertFalse(hashMap.equals(differentValueHashMap));
-    assertFalse(hashMap.equals(differentSizeHashMap));
+	// Create a HashMap
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value of Key1");
+	hashMap.put("Key2", "Value of Key2");
+	
+	// Create an other HashMap with the same data
+	HashMap<String, String> sameHashMap;
+	sameHashMap.put("Key1", "Value of Key1");
+	sameHashMap.put("Key2", "Value of Key2");
+	
+	// Create an other HashMap with the different key
+	HashMap<String, String> differentKeyHashMap;
+	differentKeyHashMap.put("different key", "Value of Key1");
+	differentKeyHashMap.put("Key2", "Value of Key2");
+	
+	// Create an other HashMap with the different value
+	HashMap<String, String> differentValueHashMap;
+	differentValueHashMap.put("Key1", "different value");
+	differentValueHashMap.put("Key2", "Value of Key2");
+	
+	// Create an other HashMap with the different size
+	HashMap<String, String> differentSizeHashMap;
+	differentSizeHashMap.put("different key", "Value of Key1");
+	
+	// Test valid case
+	assertTrue(hashMap.equals(sameHashMap));
+	
+	// Test invalid case
+	assertFalse(hashMap.equals(differentKeyHashMap));
+	assertFalse(hashMap.equals(differentValueHashMap));
+	assertFalse(hashMap.equals(differentSizeHashMap));
 }
 
 TEST (JavaUtil, HashMapReinitialize) {
-    // Create a HashMap
-    HashMap<String, String> hashMap;
-    hashMap.put("Key1", "Value of Key1");
-    hashMap.put("Key2", "Value of Key2");
-
-    // Reinitialize
-    hashMap.reinitialize();
-
-    // Make sure hashMap has been reinitialized
-    assertTrue(hashMap.isEmpty());
-    assertEquals(0, hashMap.size());
-    assertEquals("{}", hashMap.toString());
+	// Create a HashMap
+	HashMap<String, String> hashMap;
+	hashMap.put("Key1", "Value of Key1");
+	hashMap.put("Key2", "Value of Key2");
+	
+	// Reinitialize
+	hashMap.reinitialize();
+	
+	// Make sure hashMap has been reinitialized
+	assertTrue(hashMap.isEmpty());
+	assertEquals(0, hashMap.size());
+	assertEquals("{}", hashMap.toString());
 }
 
 //TEST(JavaUtil, HashMapReplaceAll) {


### PR DESCRIPTION
Java.Util.HashMap is an un-ordered hash map. Current implementation is using ordered hash map so it can be affected serious to performance. I tested with 100.000 records from MySQL and it seems super slow.

Changes:
- Replaced std::map with std::unordered_map
- Fixed wrong name for Java::Lang::Byte